### PR TITLE
feat/Fuzzy search through fuse.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "npm": ">=8.1.0"
     },
     "dependencies": {
-        "fs-extra": "9.1.0"
+        "fs-extra": "9.1.0",
+        "fuse.js": "^6.5.3"
     },
     "devDependencies": {
         "@sveltejs/svelte-virtual-list": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
         "npm": ">=8.1.0"
     },
     "dependencies": {
-        "fs-extra": "9.1.0",
-        "fuse.js": "^6.5.3"
+        "fs-extra": "9.1.0"
     },
     "devDependencies": {
         "@sveltejs/svelte-virtual-list": "^3.0.1",
@@ -42,6 +41,7 @@
         "carbon-components-svelte": "^0.51.2",
         "carbon-icons-svelte": "^10.44.3",
         "eslint": "^8.6.0",
+        "fuse.js": "^6.5.3",
         "jest": "^27.4.7",
         "jest-junit": "^13.0.0",
         "jest-mock-extended": "^2.0.4",

--- a/src/frontend/classic/components/MediaSelect.svelte
+++ b/src/frontend/classic/components/MediaSelect.svelte
@@ -6,7 +6,7 @@
         InlineLoading,
     } from "carbon-components-svelte";
     import PlugFilled16 from "carbon-icons-svelte/lib/PlugFilled16";
-    var Fuse = require("fuse.js");
+    import Fuse from "fuse.js";
 
     import { fade } from "svelte/transition";
 
@@ -27,6 +27,12 @@
 
     let medias: IMediaContainer[] = [];
     let filteredmedias: IMediaContainer[] = [];
+    let fuse = new Fuse(medias, {
+      keys: ["Title"],
+      findAllMatches: true,
+      ignoreLocation: true,
+      minMatchCharLength: 1,
+    });
 
     let selectedPlugin: IMediaContainer | undefined;
     let selectedMedia: IMediaContainer | undefined;
@@ -44,23 +50,18 @@
     //On: PluginChange
     $: {
         medias = (selectedPlugin?.Entries as IMediaContainer[]) ?? [];
+        fuse = new Fuse(medias, {
+          keys: ["Title"],
+          findAllMatches: true,
+          ignoreLocation: true,
+          minMatchCharLength: 1,
+        });
         selectedMedia = undefined;
         update = selectedPlugin?.Update();
     }
 
     let mediaNameFilter = "";
-    $: {
-        if (mediaNameFilter === "") filteredmedias = medias;
-        else {
-          const fuse = new Fuse(medias, {
-            keys: ["Title"],
-            findAllMatches: true,
-            ignoreLocation: true,
-            minMatchCharLength: 1,
-          });
-          filteredmedias = fuse.search(mediaNameFilter).map((item) => item.item);
-        }
-    }
+    $: filteredmedias = (mediaNameFilter === "") ? medias : fuse.search(mediaNameFilter).map((item) => item.item);
 
     let isPluginModalOpen = false;
 

--- a/src/frontend/classic/components/MediaSelect.svelte
+++ b/src/frontend/classic/components/MediaSelect.svelte
@@ -6,6 +6,7 @@
         InlineLoading,
     } from "carbon-components-svelte";
     import PlugFilled16 from "carbon-icons-svelte/lib/PlugFilled16";
+    var Fuse = require("fuse.js");
 
     import { fade } from "svelte/transition";
 
@@ -49,13 +50,16 @@
 
     let mediaNameFilter = "";
     $: {
-        filteredmedias = medias.filter((item) => {
-            return (
-                item?.Parent?.Title?.toLowerCase().indexOf(
-                    mediaNameFilter.toLowerCase()
-                ) !== -1
-            );
-        });
+        if (mediaNameFilter === "") filteredmedias = medias;
+        else {
+          const fuse = new Fuse(medias, {
+            keys: ["Title"],
+            findAllMatches: true,
+            ignoreLocation: true,
+            minMatchCharLength: 1,
+          });
+          filteredmedias = fuse.search(mediaNameFilter).map((item) => item.item);
+        }
     }
 
     let isPluginModalOpen = false;


### PR DESCRIPTION
Solves #35.

The _Fuse.js_ package has been added to the project to enhance the search option at the _Media_ (plugins). Now, titles could be found by using _fuzzy searching_ capabilities that the _Fuse.js_ package provides.
I attach a video showing this behavior below.

Take into account that this behavior could be extended to the right **combolist** if required, but it has been implemented only on the _plugin_ **combolist** search.

How this could be tested:

Select **Toonily** in the _Media List_ drop-down and search for some string in its **combolist** as shown in the video.

https://user-images.githubusercontent.com/25695302/150735919-a99f968f-2e7b-462c-a57f-c4835a8e2d3f.mp4


