### PR TITLE
refactoring image preview svelte style

### DIFF
--- a/src/frontend/classic/components/viewer/ThumbnailViewer.svelte
+++ b/src/frontend/classic/components/viewer/ThumbnailViewer.svelte
@@ -19,7 +19,7 @@
         <ThumbnailViewerImage
             page={content}
             title="Page {index}"
-            handleClick={() => toggleWideViewer(index)}
+            on:view={() => toggleWideViewer(index)}
         />
     {/each}
 </div>

--- a/src/frontend/classic/components/viewer/ThumbnailViewerImage.svelte
+++ b/src/frontend/classic/components/viewer/ThumbnailViewerImage.svelte
@@ -10,12 +10,12 @@
     export let page: IMediaItem;
     export let title: string;
 
-    let dataload : Promise<Blob>;
+    let dataload : Promise<string | Blob>;
     dataload = page.Fetch(Priority.High, new AbortController().signal)
         .then((data) => {return URL.createObjectURL(data)});
 
     onDestroy(() => {
-        dataload.then((src) => {if(src && src.startsWith('blob:')) URL.revokeObjectURL(src); })
+        dataload.then((src) => {URL.revokeObjectURL(src)})
     });
 
 </script>

--- a/src/frontend/classic/components/viewer/ThumbnailViewerImage.svelte
+++ b/src/frontend/classic/components/viewer/ThumbnailViewerImage.svelte
@@ -1,63 +1,47 @@
 <script lang="ts">
-    import { fly } from 'svelte/transition';
+    import { InlineLoading, ImageLoader } from "carbon-components-svelte";
+    import { fly, fade } from 'svelte/transition';
     import type { IMediaItem } from '../../../../engine/providers/MediaPlugin';
     import { Priority } from '../../../../engine/taskpool/DeferredTask';
+    import { createEventDispatcher } from "svelte";
+    const dispatch = createEventDispatcher();
 
     export let page: IMediaItem;
-    export let handleClick: () => void;
     export let title: string;
 
-    const spinner = 'https://gifimage.net/wp-content/uploads/2017/08/spinner-gif-13.gif';
-    const error = 'https://cms-assets.tutsplus.com/uploads/users/30/posts/23176/image/final-grey-2.png';
-
-    function mountThumbnail(element: HTMLDivElement, page: IMediaItem) {
-        updateThumbnail(element, page);
-        return {
-            update: (page: IMediaItem) => updateThumbnail(element, page),
-            destroy: () => unmountThumbnail(element)
-        };
-    }
-
-    function unmountThumbnail(element: HTMLDivElement) {
-        const url = element.style.backgroundImage.replace(/(url\(['"]?|['"]?\))/g, '');
-        if(url && url.startsWith('blob:')) {
-            URL.revokeObjectURL(url);
-        }
-    }
-
-    async function updateThumbnail(element: HTMLDivElement, page: IMediaItem) {
-        try {
-            unmountThumbnail(element);
-            const data = await page.Fetch(Priority.High, new AbortController().signal);
-            element.style.backgroundImage = `url('${URL.createObjectURL(data)}')`;
-        } catch {
-            element.style.backgroundImage = `url('${error}')`;
-        }
-    }
+    let dataload : Promise<Blob>
+    $: dataload = page.Fetch(Priority.High, new AbortController().signal);
 </script>
 
-<div
-    class="thumbnail"
-    style="background-image: url('{spinner}');"
-    on:click={handleClick}
-    {title}
-    in:fly
-    use:mountThumbnail={page}
-/>
+<div class="thumbnail" transition:fly on:click={(e) => { dispatch("view", page); }}>
+    {#await dataload}
+        <InlineLoading />
+    {:then data } 
+        <ImageLoader class="imgload" alt={title} src={URL.createObjectURL(data)} fadeIn>
+            <svelte:fragment slot="loading"><InlineLoading /></svelte:fragment>
+            <svelte:fragment slot="error"><InlineLoading status="error"/></svelte:fragment>
+        </ImageLoader>
+    {:catch error}
+        <InlineLoading status="error"/>
+    {/await}
+
+</div> 
 
 <style>
     .thumbnail {
         display: inline-block;
         border: 2px solid var(--cds-ui-04);
         background-color: var(--cds-ui-01);
-        background-position: center;
-        background-size: contain;
-        background-repeat: no-repeat;
         border-radius: 1em;
         margin: 0.5em;
         width: 16em;
         height: 16em;
         cursor: pointer;
         box-shadow: 1em 1em 2em var(--cds-ui-01);
+    }
+    .thumbnail :global(.imgload) {
+        width:100%;
+        height:100%;
+        object-fit: contain;
     }
 </style>

--- a/src/frontend/classic/components/viewer/ThumbnailViewerImage.svelte
+++ b/src/frontend/classic/components/viewer/ThumbnailViewerImage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { InlineLoading, ImageLoader } from "carbon-components-svelte";
-    import { fly, fade } from 'svelte/transition';
+    import { fly } from 'svelte/transition';
     import type { IMediaItem } from '../../../../engine/providers/MediaPlugin';
     import { Priority } from '../../../../engine/taskpool/DeferredTask';
     import { createEventDispatcher, onDestroy } from "svelte";
@@ -10,7 +10,7 @@
     export let page: IMediaItem;
     export let title: string;
 
-    let dataload : Promise<string | Blob>;
+    let dataload : Promise<string>;
     dataload = page.Fetch(Priority.High, new AbortController().signal)
         .then((data) => {return URL.createObjectURL(data)});
 
@@ -20,7 +20,7 @@
 
 </script>
 
-<div class="thumbnail" transition:fly on:click={(e) => { dispatch("view", page); }}>
+<div class="thumbnail" transition:fly on:click={() => { dispatch("view", page); }}>
     {#await dataload}
         <InlineLoading />
     {:then data}
@@ -28,7 +28,7 @@
             <svelte:fragment slot="loading"><InlineLoading /></svelte:fragment>
             <svelte:fragment slot="error"><InlineLoading status="error"/></svelte:fragment>
         </ImageLoader>
-    {:catch error}
+    {:catch}
         <InlineLoading status="error"/>
     {/await}
 

--- a/src/frontend/classic/components/viewer/Viewer.svelte
+++ b/src/frontend/classic/components/viewer/Viewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { Loading } from "carbon-components-svelte";
     import type { IMediaContainer } from '../../../../engine/providers/MediaPlugin';
     import ThumbnailViewer from './ThumbnailViewer.svelte';
     import WideViewer from './WideViewer.svelte';
@@ -25,6 +26,7 @@
 <div id="Viewer">
     <div id="Contents" class={mode}>
         {#await update}
+            <Loading withOverlay={false} />
             <p>...loading items</p>
         {:then}
             {#if mode === 'Thumbnail'}


### PR DESCRIPTION
- carbon icons for loading
- svelte event dispatch
- svelte async pattern
- carbon ImageLoader for extra 404 catching
- reworked div background image to simple img with object-fit: contain;