### PR TITLE
[Frontend Fluent-Core] Fix Handling of Invalid Download Directory

### DIFF
--- a/web/src/engine/providers/MangaPlugin.ts
+++ b/web/src/engine/providers/MangaPlugin.ts
@@ -1,3 +1,4 @@
+import { GetLocale } from '../../i18n/Localization';
 import { Key, Scope } from '../SettingsGlobal';
 import type { Check, Directory, ISettings, SettingsManager } from '../SettingsManager';
 import { SanitizeFileName, type StorageController, Store } from '../StorageController';
@@ -155,10 +156,10 @@ export class Chapter extends StoreableMediaContainer<Page> {
         const settings = HakuNeko.SettingsManager.OpenScope(Scope);
         let directory = settings.Get<Directory>(Key.MediaDirectory).Value;
         if(!directory) {
-            throw new Error();
+            throw new Error(GetLocale().Settings_Global_MediaDirectory_UnsetError());
         }
         if(await directory.requestPermission() !== 'granted') {
-            throw new Error(); // user denied permission ...
+            throw new Error(GetLocale().Settings_Global_MediaDirectory_PermissionError());
         }
         if(settings.Get<Check>(Key.UseWebsiteSubDirectory).Value && this.Parent?.Parent) {
             const website = SanitizeFileName(this.Parent?.Parent?.Title);

--- a/web/src/frontend/fluent-core/components/DownloadManagerTask.ts
+++ b/web/src/frontend/fluent-core/components/DownloadManagerTask.ts
@@ -128,7 +128,7 @@ export class DownloadManagerTask extends FASTElement {
                 'titlebar=no',
                 'menubar=no',
                 'toolbar=no',
-                'ocation=no',
+                'location=no',
                 'status=no',
                 'scrollbars=yes',
                 'resizable=yes',

--- a/web/src/frontend/fluent-core/components/DownloadManagerTask.ts
+++ b/web/src/frontend/fluent-core/components/DownloadManagerTask.ts
@@ -65,6 +65,7 @@ const styles: ElementStyles = css`
     }
 
     .status.${Status.Failed} svg {
+        cursor: pointer;
         fill: #FF6060;
     }
 
@@ -78,7 +79,7 @@ const template: ViewTemplate<DownloadManagerTask> = html`
     <div class="mediaitem">${model => model.entry?.Media.Title}</div>
     <div class="controls">
         <fluent-progress min="0" max="1" :paused=${() => false} :value=${model => model.progress}></fluent-progress>
-        <div class="status ${model => model.status}" :innerHTML=${model => StatusIcons[model.status]}></div>
+        <div class="status ${model => model.status}" :innerHTML=${model => StatusIcons[model.status]} @click=${model => model.ShowErrors()}></div>
         <fluent-button appearance="stealth" title="${() => S.Locale.Frontend_FluentCore_DownloadManagerTask_RemoveButton_Description()}" @click=${model => HakuNeko.DownloadManager.Dequeue(model.entry)}>${IconRemove}</fluent-button>
     </div>
 `;
@@ -116,4 +117,24 @@ export class DownloadManagerTask extends FASTElement {
     private UpdateProgress = function (_: IDownloadTask, value?: number) {
         this.progress = value ?? 0;
     }.bind(this);
+
+    public ShowErrors() {
+        if(this.entry.Errors.length > 0) {
+            // TODO: Show all errors in a fancy error dialog ...
+            const message = this.entry.Errors.map(error => {
+                return `<div>Message: ${error.message}</div><pre>${error.stack}</pre>`;
+            }).join('<hr>');
+            window.open(null, '_blank', [
+                'titlebar=no',
+                'menubar=no',
+                'toolbar=no',
+                'ocation=no',
+                'status=no',
+                'scrollbars=yes',
+                'resizable=yes',
+                'width=800',
+                'height=480'
+            ].join(', ')).document.write(message);
+        }
+    }
 }

--- a/web/src/frontend/fluent-core/components/DownloadManagerTask.ts
+++ b/web/src/frontend/fluent-core/components/DownloadManagerTask.ts
@@ -122,7 +122,7 @@ export class DownloadManagerTask extends FASTElement {
         if(this.entry.Errors.length > 0) {
             // TODO: Show all errors in a fancy error dialog ...
             const message = this.entry.Errors.map(error => {
-                return `<div>Message: ${error.message}</div><pre>${error.stack}</pre>`;
+                return `<div>${error.message}</div><pre>${error.stack}</pre>`;
             }).join('<hr>');
             window.open(null, '_blank', [
                 'titlebar=no',

--- a/web/src/frontend/fluent-core/components/SettingsDialog.ts
+++ b/web/src/frontend/fluent-core/components/SettingsDialog.ts
@@ -82,7 +82,7 @@ const templateChoice: ViewTemplate<Choice> = html`
 `;
 
 const templateDirectory: ViewTemplate<Directory> = html`
-    <fluent-text-field readonly id="${model => model.ID}" :value=${model => model.Value.name}>
+    <fluent-text-field readonly id="${model => model.ID}" :value=${model => model.Value?.name}>
     <div slot="end" style="display: flex; align-items: center;">
         <fluent-button appearance="stealth" style="height: fit-content;" @click=${(model, ctx) => (ctx.parent as SettingsDialog).SelectDirectory(model)}>${IconFolder}</fluent-button>
     </div>

--- a/web/src/i18n/ILocale.ts
+++ b/web/src/i18n/ILocale.ts
@@ -156,6 +156,8 @@ export enum VariantResourceKey {
     Settings_Global_LanguageInfo = 'Settings_Global_LanguageInfo',
     Settings_Global_MediaDirectory = 'Settings_Global_MediaDirectory',
     Settings_Global_MediaDirectoryInfo = 'Settings_Global_MediaDirectoryInfo',
+    Settings_Global_MediaDirectory_UnsetError = 'Settings_Global_MediaDirectory_UnsetError',
+    Settings_Global_MediaDirectory_PermissionError = 'Settings_Global_MediaDirectory_PermissionError',
     Settings_Global_WebsiteSubDirectory = 'Settings_Global_WebsiteSubDirectory',
     Settings_Global_WebsiteSubDirectoryInfo = 'Settings_Global_WebsiteSubDirectoryInfo',
     Settings_Global_DescramblingFormat = 'Settings_Global_DescramblingFormat',

--- a/web/src/i18n/locales/en_US.ts
+++ b/web/src/i18n/locales/en_US.ts
@@ -131,6 +131,8 @@ export const en_US: IVariantResource = {
     Settings_Global_LanguageInfo: 'Select the language for the user interface',
     Settings_Global_MediaDirectory: 'Media Directory',
     Settings_Global_MediaDirectoryInfo: 'Select the directory where HakuNeko store the downloads',
+    Settings_Global_MediaDirectory_UnsetError: 'No download directory selected in HakuNeko settings!',
+    Settings_Global_MediaDirectory_PermissionError: 'Insufficient permission to acces the download directory!',
     Settings_Global_WebsiteSubDirectory: 'Use Sub-Directories',
     Settings_Global_WebsiteSubDirectoryInfo: 'Set wether HakuNeko shall store media directly in the directory, or use sub-directories per website',
     Settings_Global_DescramblingFormat: 'De-Scrambling Format',


### PR DESCRIPTION
- Fix binding error in UI component
- Add ability to show download errors in a provisional error dialog

<img width="930" alt="Screenshot 2023-01-22 at 15 35 30" src="https://user-images.githubusercontent.com/27136773/213921588-5e81504b-a74f-4b4a-a595-682334fda284.png">