### PR TITLE
UI classic: settings store more svelte like

### DIFF
--- a/web/src/frontend/classic/App.svelte
+++ b/web/src/frontend/classic/App.svelte
@@ -22,7 +22,7 @@
     import UserMessage from './components/UserMessages.svelte';
     import ContentPage from './components/content-pages/ContentRouter.svelte';
     // UI: Stores
-    import { ContentPanelValue, ThemeValue } from './stores/Settings';
+    import { ContentPanel, Theme as ThemeSetting } from './stores/Settings';
     import { selectedItem } from './stores/Stores';
 
     let resolveFinishLoading: (value: void | PromiseLike<void>) => void;
@@ -44,7 +44,7 @@
 
     let showHome = true;
 
-    $: uimode = $ContentPanelValue ? 'ui-mode-content' : 'ui-mode-download';
+    $: uimode = $ContentPanel ? 'ui-mode-content' : 'ui-mode-download';
 
     $: if (app) {
         const oldUimode =
@@ -58,7 +58,7 @@
 
 <UserMessage />
 
-<Theme theme={$ThemeValue}>
+<Theme theme={$ThemeSetting}>
     <AppBar on:home={() => ($selectedItem = null)} />
     <Content id="hakunekoapp">
         <MediaSelect />

--- a/web/src/frontend/classic/components/MediaSelect.svelte
+++ b/web/src/frontend/classic/components/MediaSelect.svelte
@@ -23,7 +23,7 @@
         selectedMedia,
         selectedItem,
     } from '../stores/Stores';
-    import { FuzzySearchValue } from '../stores/Settings';
+    import { FuzzySearch } from '../stores/Settings';
     // Hakuneko Engine
     import type { IMediaContainer } from '../../../engine/providers/MediaPlugin';
     import type { IMediaInfoTracker } from '../../../engine/trackers/IMediaInfoTracker';
@@ -94,7 +94,7 @@
     }
 
     function filterMedia(mediaNameFilter: string): IMediaContainer[] {
-        if ($FuzzySearchValue)
+        if ($FuzzySearch)
             return fuse.search(mediaNameFilter).map((item) => item.item);
         else
             return medias.filter((item) =>

--- a/web/src/frontend/classic/components/settings/SettingsPanel.svelte
+++ b/web/src/frontend/classic/components/settings/SettingsPanel.svelte
@@ -3,89 +3,68 @@
     import SettingItem from './SettingItem.svelte';
     import {
         ContentPanel,
-        ContentPanelValue,
         Key,
         Locale,
         FuzzySearch,
-        FuzzySearchValue,
         Theme,
-        ThemeValue,
         ViewerDoublePage,
-        ViewerDoublePageValue,
         ViewerMode,
-        ViewerModeValue,
         ViewerReverseDirection,
-        ViewerReverseDirectionValue,
     } from '../../stores/Settings';
+    import type { Choice } from '../../../../engine/SettingsManager';
+
+    const ThemeSetting = Theme.setting as Choice;
+    const ViewModeSetting = ViewerMode.setting as Choice;
 </script>
 
 <SettingItem
-    labelText={$Locale[ContentPanel.Label]()}
-    helperText={$Locale[ContentPanel.Description]()}
+    labelText={$Locale[ContentPanel.setting.Label]()}
+    helperText={$Locale[ContentPanel.setting.Description]()}
 >
-    <Toggle
-        toggled={$ContentPanelValue}
-        on:toggle={(evt) => (ContentPanel.Value = evt.detail.toggled)}
-    />
+    <Toggle bind:toggled={$ContentPanel} />
 </SettingItem>
 
 <SettingItem
-    labelText={$Locale[Theme.Label]()}
-    helperText={$Locale[Theme.Description]()}
+    labelText={$Locale[Theme.setting.Label]()}
+    helperText={$Locale[Theme.setting.Description]()}
 >
-    <Select
-        selected={$ThemeValue}
-        on:update={(evt) => (Theme.Value = evt.detail.toString())}
-    >
-        {#each Theme.Options as option}
+    <Select bind:selected={$Theme}>
+        {#each ThemeSetting.Options as option}
             <SelectItem value={option.key} text={$Locale[option.label]()} />
         {/each}
     </Select>
 </SettingItem>
 
 <SettingItem
-    labelText={$Locale[ViewerMode.Label]()}
-    helperText={$Locale[ViewerMode.Description]()}
+    labelText={$Locale[ViewerMode.setting.Label]()}
+    helperText={$Locale[ViewerMode.setting.Description]()}
 >
-    <Select
-        selected={$ViewerModeValue}
-        on:update={(evt) => (ViewerMode.Value = evt.detail.toString())}
-    >
-        {#each ViewerMode.Options as option}
+    <Select bind:selected={$ViewerMode}>
+        {#each ViewModeSetting.Options as option}
             <SelectItem value={option.key} text={$Locale[option.label]()} />
         {/each}
     </Select>
 </SettingItem>
 
-{#if $ViewerModeValue === Key.ViewerMode_Paginated}
+{#if $ViewerMode === Key.ViewerMode_Paginated}
     <SettingItem
-        labelText={$Locale[ViewerReverseDirection.Label]()}
-        helperText={$Locale[ViewerReverseDirection.Description]()}
+        labelText={$Locale[ViewerReverseDirection.setting.Label]()}
+        helperText={$Locale[ViewerReverseDirection.setting.Description]()}
     >
-        <Toggle
-            toggled={$ViewerReverseDirectionValue}
-            on:toggle={(evt) =>
-                (ViewerReverseDirection.Value = evt.detail.toggled)}
-        />
+        <Toggle bind:toggled={$ViewerReverseDirection} />
     </SettingItem>
 
     <SettingItem
-        labelText={$Locale[ViewerDoublePage.Label]()}
-        helperText={$Locale[ViewerDoublePage.Description]()}
+        labelText={$Locale[ViewerDoublePage.setting.Label]()}
+        helperText={$Locale[ViewerDoublePage.setting.Description]()}
     >
-        <Toggle
-            toggled={$ViewerDoublePageValue}
-            on:toggle={(evt) => (ViewerDoublePage.Value = evt.detail.toggled)}
-        />
+        <Toggle bind:toggled={$ViewerDoublePage} />
     </SettingItem>
 {/if}
 
 <SettingItem
-    labelText={$Locale[FuzzySearch.Label]()}
-    helperText={$Locale[FuzzySearch.Description]()}
+    labelText={$Locale[FuzzySearch.setting.Label]()}
+    helperText={$Locale[FuzzySearch.setting.Description]()}
 >
-    <Toggle
-        toggled={$FuzzySearchValue}
-        on:toggle={(evt) => (FuzzySearch.Value = evt.detail.toggled)}
-    />
+    <Toggle bind:toggled={$FuzzySearch} />
 </SettingItem>

--- a/web/src/frontend/classic/components/settings/SettingsPanel.svelte
+++ b/web/src/frontend/classic/components/settings/SettingsPanel.svelte
@@ -11,10 +11,6 @@
         ViewerMode,
         ViewerReverseDirection,
     } from '../../stores/Settings';
-    import type { Choice } from '../../../../engine/SettingsManager';
-
-    const ThemeSetting = Theme.setting as Choice;
-    const ViewModeSetting = ViewerMode.setting as Choice;
 </script>
 
 <SettingItem
@@ -29,7 +25,7 @@
     helperText={$Locale[Theme.setting.Description]()}
 >
     <Select bind:selected={$Theme}>
-        {#each ThemeSetting.Options as option}
+        {#each Theme.setting.Options as option}
             <SelectItem value={option.key} text={$Locale[option.label]()} />
         {/each}
     </Select>
@@ -40,7 +36,7 @@
     helperText={$Locale[ViewerMode.setting.Description]()}
 >
     <Select bind:selected={$ViewerMode}>
-        {#each ViewModeSetting.Options as option}
+        {#each ViewerMode.setting.Options as option}
             <SelectItem value={option.key} text={$Locale[option.label]()} />
         {/each}
     </Select>

--- a/web/src/frontend/classic/components/viewer/ImageViewer.svelte
+++ b/web/src/frontend/classic/components/viewer/ImageViewer.svelte
@@ -4,24 +4,33 @@
     // UI
     import { InlineNotification } from 'carbon-components-svelte';
     // engine
-    import type { IMediaContainer,IMediaItem } from '../../../../engine/providers/MediaPlugin';
+    import type {
+        IMediaContainer,
+        IMediaItem,
+    } from '../../../../engine/providers/MediaPlugin';
     // svelte component
     import ImageViewerWideSettings from './ImageViewerWideSettings.svelte';
     import Image from './Image.svelte';
     // stores
-    import { Key, ViewerModeValue, ViewerPadding, ViewerZoom, ViewerReverseDirectionValue } from '../../stores/Settings';
+    import {
+        Key,
+        ViewerMode,
+        ViewerPadding,
+        ViewerZoom,
+        ViewerReverseDirection,
+    } from '../../stores/Settings';
     import { selectedItemNext } from '../../stores/Stores';
     // others
     import { scrollSmoothly, scrollMagic } from './utilities';
 
     export let item: IMediaContainer;
-    export let currentImageIndex: number=-1;
-    export let wide:Boolean;
+    export let currentImageIndex: number = -1;
+    export let wide: Boolean;
 
-	onDestroy(() => {
+    onDestroy(() => {
         document.removeEventListener('keydown', onKeyDown);
         viewer?.removeEventListener('mousedown', onMouseDown);
-	});
+    });
 
     $: entries = item.Entries as IMediaItem[];
 
@@ -50,7 +59,7 @@
                     behavior: 'smooth',
                 });
                 break;
-            case event.code === 'ArrowRight' :
+            case event.code === 'ArrowRight':
                 dispatch('nextItem');
                 break;
             case event.code === 'ArrowLeft':
@@ -59,7 +68,7 @@
             case event.key === '*':
                 $ViewerZoom = 100;
                 break;
-            case event.key === '/' :
+            case event.key === '/':
                 ViewerZoom.reset();
                 break;
             case event.key === '+' && !event.ctrlKey:
@@ -90,8 +99,8 @@
         }
     }
 
-    let previousOffset = { x : 0, y : 0 };
-    let previousSize = { width : 0, height : 0 };
+    let previousOffset = { x: 0, y: 0 };
+    let previousSize = { width: 0, height: 0 };
 
     /**
      *
@@ -110,18 +119,22 @@
     }
 
     const zoomObserver = new ResizeObserver(function () {
-        switch ($ViewerModeValue){
-            case Key.ViewerMode_Longstrip : {
+        switch ($ViewerMode) {
+            case Key.ViewerMode_Longstrip: {
                 viewer.scrollTo({
-                    top: viewer.scrollHeight * (previousOffset.y/ previousSize.height),
-                    behavior: 'smooth'
+                    top:
+                        viewer.scrollHeight *
+                        (previousOffset.y / previousSize.height),
+                    behavior: 'smooth',
                 });
                 break;
             }
             case Key.ViewerMode_Paginated: {
                 viewer.scrollTo({
-                    left: viewer.scrollWidth * (previousOffset.x/ previousSize.width),
-                    behavior: 'smooth'
+                    left:
+                        viewer.scrollWidth *
+                        (previousOffset.x / previousSize.width),
+                    behavior: 'smooth',
                 });
                 break;
             }
@@ -129,8 +142,11 @@
     });
 
     function observeZoom() {
-        previousOffset = { x : viewer.scrollTop, y : viewer.scrollLeft };
-        previousSize = { width: viewer.scrollWidth, height : viewer.scrollHeight };
+        previousOffset = { x: viewer.scrollTop, y: viewer.scrollLeft };
+        previousSize = {
+            width: viewer.scrollWidth,
+            height: viewer.scrollHeight,
+        };
         zoomObserver.disconnect();
         // We observe the size of all children to detect the full container scrollHeight change
         for (var i = 0; i < viewer.children.length; i++) {
@@ -152,7 +168,6 @@
     let pos = { top: 0, left: 0, x: 0, y: 0 };
 
     function onMouseDown(e: MouseEvent) {
-        
         viewer.style.cursor = 'grabbing';
         viewer.style.userSelect = 'none';
         pos = {
@@ -186,34 +201,52 @@
         viewer.style.removeProperty('user-select');
     };
 
-	$: cssvars = {
-		'viewer-padding': `${$ViewerPadding}em`,
-	};
+    $: cssvars = {
+        'viewer-padding': `${$ViewerPadding}em`,
+    };
     $: cssVarStyles = Object.entries(cssvars)
-		.map(([key, value]) => `--${key}:${value}`)
-		.join(';');
+        .map(([key, value]) => `--${key}:${value}`)
+        .join(';');
 
-	$: if (wide) {
-            if(currentImageIndex != -1) {
-                // delay because of smooth transition
-                setTimeout(() => {
-                    const targetScrollImage = viewer.querySelectorAll('ImageViewer>img')[currentImageIndex];
-                    targetScrollImage?.scrollIntoView({behavior: 'smooth', inline:'center'});
-                    currentImageIndex=-1;
-                }, 200);
-            }
-            document.addEventListener('keydown', onKeyDown);
-            viewer?.addEventListener('mousedown', onMouseDown); 
+    $: if (wide) {
+        if (currentImageIndex != -1) {
+            // delay because of smooth transition
+            setTimeout(() => {
+                const targetScrollImage =
+                    viewer.querySelectorAll('ImageViewer>img')[
+                        currentImageIndex
+                    ];
+                targetScrollImage?.scrollIntoView({
+                    behavior: 'smooth',
+                    inline: 'center',
+                });
+                currentImageIndex = -1;
+            }, 200);
         }
-        else {
-            document.removeEventListener('keydown', onKeyDown);
-            viewer?.removeEventListener('mousedown', onMouseDown);
-            if(viewer) viewer.style.userSelect = 'none';
-        }
+        document.addEventListener('keydown', onKeyDown);
+        viewer?.addEventListener('mousedown', onMouseDown);
+    } else {
+        document.removeEventListener('keydown', onKeyDown);
+        viewer?.removeEventListener('mousedown', onMouseDown);
+        if (viewer) viewer.style.userSelect = 'none';
+    }
 </script>
-<div id="ImageViewer" bind:this={viewer} class="{wide?'wide':'thumbnail'} {$ViewerModeValue} {$ViewerReverseDirectionValue ? 'reverse':''}" style="{cssVarStyles}">
+
+<div
+    id="ImageViewer"
+    bind:this={viewer}
+    class="{wide ? 'wide' : 'thumbnail'} {$ViewerMode} {$ViewerReverseDirection
+        ? 'reverse'
+        : ''}"
+    style={cssVarStyles}
+>
     {#if wide}
-        <ImageViewerWideSettings {title} on:nextItem on:previousItem on:close={() => wide = false} />
+        <ImageViewerWideSettings
+            {title}
+            on:nextItem
+            on:previousItem
+            on:close={() => (wide = false)}
+        />
     {/if}
     {#if entries.length === 0}
         <div class="center" style="width:100%;height:100%;">
@@ -227,10 +260,16 @@
     {/if}
 
     {#each entries as content, index (index)}
-        <Image class="{wide?'wide':'thumbnail'}" alt="content_{index}" page={content}
-            on:click={() => {currentImageIndex = index; wide=true; }}
+        <Image
+            class={wide ? 'wide' : 'thumbnail'}
+            alt="content_{index}"
+            page={content}
+            on:click={() => {
+                currentImageIndex = index;
+                wide = true;
+            }}
         />
-    {/each} 
+    {/each}
     {#if autoNextItem && $selectedItemNext !== undefined}
         <InlineNotification
             kind="info"
@@ -248,8 +287,7 @@
         width: 100%;
         height: 100%;
     }
-    #ImageViewer.thumbnail
-    {
+    #ImageViewer.thumbnail {
         overflow-y: auto;
         display: flex;
         flex-wrap: wrap;
@@ -266,9 +304,9 @@
         width: 16em;
         height: 16em;
         min-width: 16em;
-        min-height:16em;
+        min-height: 16em;
         max-width: 16em;
-        max-height:16em;
+        max-height: 16em;
         cursor: pointer;
         object-fit: contain;
     }
@@ -276,7 +314,7 @@
         overflow: auto;
         background-color: var(--cds-ui-01);
         cursor: grab;
-        align-items:center;
+        align-items: center;
         transition: gap 0.2s ease-in-out;
         gap: var(--viewer-padding);
         min-width: 0;
@@ -285,16 +323,15 @@
     #ImageViewer.wide.longstrip {
         display: flex;
         flex-direction: column;
-        overflow-y:auto;
-
+        overflow-y: auto;
     }
     #ImageViewer.wide.paginated {
         display: flex;
         flex-direction: row;
         flex-wrap: nowrap;
         align-items: center;
-        height:100%;
-        overflow-x:auto;
+        height: 100%;
+        overflow-x: auto;
     }
     /* TODO: implement RTL reading */
     #ImageViewer.wide.paginated.reverse {

--- a/web/src/frontend/classic/stores/Helpers.ts
+++ b/web/src/frontend/classic/stores/Helpers.ts
@@ -1,0 +1,47 @@
+import { writable } from 'svelte/store';
+import type { IValue, Setting} from '../../../engine/SettingsManager';
+import type { Key } from '../../../engine/SettingsGlobal';
+
+const globalsettings = HakuNeko.SettingsManager.OpenScope();
+
+/**
+ * Create a writable svelte store that is coupled with the given setting
+ * and updated whenever the value of the underlying setting is changed.
+ * @param setting - a specific setting of the frontend
+ */
+export function CreateWritableStore<T extends IValue>(setting:Setting<T>) {
+    const { subscribe, set } = writable(setting.Default);
+
+    setting.ValueChanged.Subscribe(
+        (_: typeof setting, value: T) => set(value)
+    );
+    return {
+        subscribe,
+        set: (value: T) => { setting.Value = value; set(value); },
+        reset: () => { setting.Value = setting.Default; set(setting.Default); },
+        setting : setting
+    };
+}
+
+/**
+ * Create a writable svelte store that is coupled with the given setting
+ * and updated whenever the value of the underlying setting is changed.
+ * @param settingKey - an existing key (created in the engine)
+ */
+export function GetEngineSetting<T extends IValue>(settingKey: Key) {
+    const setting: Setting<T> = globalsettings.Get(settingKey);
+    if (!setting) throw new Error(`Setting ${settingKey} does not exists`);
+    return CreateWritableStore<T>(setting);
+}
+
+export function CreateCountStore(initialValue:number, increment:number,minimum = -Infinity, maximum = Infinity) {
+    const { subscribe, set, update } = writable(initialValue);
+
+    return {
+        subscribe,
+        set,
+        increment: () => update(n => n + increment <= maximum ? n + increment : n),
+        decrement: () => update(n => n - increment >= minimum ? n - increment : n),
+        reset: () => set(initialValue)
+    };
+}

--- a/web/src/frontend/classic/stores/Settings.ts
+++ b/web/src/frontend/classic/stores/Settings.ts
@@ -3,7 +3,7 @@ import { type ILocale, VariantResourceKey as R } from '../../../i18n/ILocale';
 import { GetLocale } from '../../../i18n/Localization';
 import { Check, Choice} from '../../../engine/SettingsManager';
 import { Key as GlobalKey } from '../../../engine/SettingsGlobal';
-import { CreateCountStore, CreateWritableStore, GetEngineSetting } from './Helpers';
+import { CreateCountStore, CreateSettingStore, CreateExistingSettingStore } from './Helpers';
 
 const scope = 'frontend.classic';
 
@@ -45,7 +45,7 @@ export async function Initialize(): Promise<void> {
 
 export const Locale = writable<ILocale>(GetLocale());
 
-export const Theme= CreateWritableStore<string>(new Choice(
+export const Theme= CreateSettingStore<string>(new Choice(
     Key.Theme,
     R.Frontend_Classic_Settings_Theme,
     R.Frontend_Classic_Settings_ThemeInfo,
@@ -58,21 +58,21 @@ export const Theme= CreateWritableStore<string>(new Choice(
     { key: Key.Theme_SheepyNeko, label: R.Frontend_Classic_Settings_Theme_SheepyNeko },
 ));
 
-export const ContentPanel = CreateWritableStore<boolean>(new Check(
+export const ContentPanel = CreateSettingStore<boolean>(new Check(
     Key.ContentPanel,
     R.Frontend_Classic_Settings_ContentPanel,
     R.Frontend_Classic_Settings_ContentPanelInfo,
     true
 ));
 
-export const FuzzySearch= CreateWritableStore<boolean>(new Check(
+export const FuzzySearch= CreateSettingStore<boolean>(new Check(
     Key.FuzzySearch,
     R.Frontend_Classic_Settings_FuzzySearch,
     R.Frontend_Classic_Settings_FuzzySearchInfo,
     true
 ));
 
-export const ViewerMode = CreateWritableStore<string>(new Choice(
+export const ViewerMode = CreateSettingStore<string>(new Choice(
     Key.ViewerMode,
     R.Frontend_Classic_Settings_ViewerMode,
     R.Frontend_Classic_Settings_ViewerModeInfo,
@@ -81,21 +81,21 @@ export const ViewerMode = CreateWritableStore<string>(new Choice(
     { key: Key.ViewerMode_Longstrip, label: R.Frontend_Classic_Settings_ViewerMode_Longstrip },
 ));
 
-export const ViewerReverseDirection = CreateWritableStore<boolean>( new Check(
+export const ViewerReverseDirection = CreateSettingStore<boolean>( new Check(
     Key.ViewerReverseDirection,
     R.Frontend_Classic_Settings_ViewerReverseDirection,
     R.Frontend_Classic_Settings_ViewerReverseDirectionInfo,
     false
 ));
 
-export const ViewerDoublePage = CreateWritableStore<boolean>(new Check(
+export const ViewerDoublePage = CreateSettingStore<boolean>(new Check(
     Key.ViewerDoublePage,
     R.Frontend_Classic_Settings_ViewerDoublePage,
     R.Frontend_Classic_Settings_ViewerDoublePageInfo,
     false
 ));
 
-export const checkNewContent = GetEngineSetting<boolean>(GlobalKey.CheckNewContent);
+export const checkNewContent = CreateExistingSettingStore<boolean>(GlobalKey.CheckNewContent);
 
 // Non persistant settings
 /** Viewer **/

--- a/web/src/frontend/classic/stores/Settings.ts
+++ b/web/src/frontend/classic/stores/Settings.ts
@@ -3,7 +3,7 @@ import { type ILocale, VariantResourceKey as R } from '../../../i18n/ILocale';
 import { GetLocale } from '../../../i18n/Localization';
 import { Check, Choice} from '../../../engine/SettingsManager';
 import { Key as GlobalKey } from '../../../engine/SettingsGlobal';
-import { CreateCountStore, CreateSettingStore, CreateExistingSettingStore } from './Helpers';
+import { CreateCountStore, CreateSettingStore, CreateExistingSettingStore } from './storesHelpers';
 
 const scope = 'frontend.classic';
 
@@ -45,7 +45,7 @@ export async function Initialize(): Promise<void> {
 
 export const Locale = writable<ILocale>(GetLocale());
 
-export const Theme= CreateSettingStore<string>(new Choice(
+export const Theme= CreateSettingStore<string,Choice>(new Choice(
     Key.Theme,
     R.Frontend_Classic_Settings_Theme,
     R.Frontend_Classic_Settings_ThemeInfo,
@@ -58,21 +58,21 @@ export const Theme= CreateSettingStore<string>(new Choice(
     { key: Key.Theme_SheepyNeko, label: R.Frontend_Classic_Settings_Theme_SheepyNeko },
 ));
 
-export const ContentPanel = CreateSettingStore<boolean>(new Check(
+export const ContentPanel = CreateSettingStore<boolean,Check>(new Check(
     Key.ContentPanel,
     R.Frontend_Classic_Settings_ContentPanel,
     R.Frontend_Classic_Settings_ContentPanelInfo,
     true
 ));
 
-export const FuzzySearch= CreateSettingStore<boolean>(new Check(
+export const FuzzySearch= CreateSettingStore<boolean,Check>(new Check(
     Key.FuzzySearch,
     R.Frontend_Classic_Settings_FuzzySearch,
     R.Frontend_Classic_Settings_FuzzySearchInfo,
     true
 ));
 
-export const ViewerMode = CreateSettingStore<string>(new Choice(
+export const ViewerMode = CreateSettingStore<string,Choice>(new Choice(
     Key.ViewerMode,
     R.Frontend_Classic_Settings_ViewerMode,
     R.Frontend_Classic_Settings_ViewerModeInfo,
@@ -81,21 +81,21 @@ export const ViewerMode = CreateSettingStore<string>(new Choice(
     { key: Key.ViewerMode_Longstrip, label: R.Frontend_Classic_Settings_ViewerMode_Longstrip },
 ));
 
-export const ViewerReverseDirection = CreateSettingStore<boolean>( new Check(
+export const ViewerReverseDirection = CreateSettingStore<boolean,Check>( new Check(
     Key.ViewerReverseDirection,
     R.Frontend_Classic_Settings_ViewerReverseDirection,
     R.Frontend_Classic_Settings_ViewerReverseDirectionInfo,
     false
 ));
 
-export const ViewerDoublePage = CreateSettingStore<boolean>(new Check(
+export const ViewerDoublePage = CreateSettingStore<boolean,Check>(new Check(
     Key.ViewerDoublePage,
     R.Frontend_Classic_Settings_ViewerDoublePage,
     R.Frontend_Classic_Settings_ViewerDoublePageInfo,
     false
 ));
 
-export const checkNewContent = CreateExistingSettingStore<boolean>(GlobalKey.CheckNewContent);
+export const checkNewContent = CreateExistingSettingStore<boolean,Check>(GlobalKey.CheckNewContent);
 
 // Non persistant settings
 /** Viewer **/

--- a/web/src/frontend/classic/stores/Stores.ts
+++ b/web/src/frontend/classic/stores/Stores.ts
@@ -1,7 +1,9 @@
-import { writable } from 'svelte/store';
+import { readable, writable } from 'svelte/store';
 import type { IWindowController } from '../../WindowController';
 import { CreateWindowController } from '../../WindowController';
 import type { IMediaContainer } from '../../../engine/providers/MediaPlugin';
+import type { Bookmark } from '../../../engine/providers/BookmarkPlugin';
+import { checkNewContent } from './Settings';
 
 export const WindowController = writable<IWindowController>(CreateWindowController());
 export const selectedPlugin = writable<IMediaContainer>();
@@ -9,3 +11,15 @@ export const selectedMedia = writable<IMediaContainer>();
 export const selectedItem = writable<IMediaContainer>();
 export const selectedItemPrevious = writable<IMediaContainer>();
 export const selectedItemNext = writable<IMediaContainer>();
+
+export const bookmarksToContinue = readable<Bookmark[]>([], (set) => {
+    async function refreshSuggestions() {
+        set(await HakuNeko.BookmarkPlugin.getEntriesWithUnflaggedContent());
+    }
+    refreshSuggestions();
+    const unsubcribe = checkNewContent.subscribe(shouldCheck => {
+        if (shouldCheck) refreshSuggestions();
+    });
+
+    return function stop() { unsubcribe; };
+});

--- a/web/src/frontend/classic/stores/storesHelpers.ts
+++ b/web/src/frontend/classic/stores/storesHelpers.ts
@@ -4,8 +4,8 @@ import type { Key } from '../../../engine/SettingsGlobal';
 
 const globalsettings = HakuNeko.SettingsManager.OpenScope();
 
-interface SettingStore<T extends IValue> extends Writable<T> {
-    setting: Setting<IValue>,
+interface SettingStore<V extends IValue, S extends Setting<V>> extends Writable<V> {
+    setting: S,
     reset() : void
 }
 
@@ -14,16 +14,16 @@ interface SettingStore<T extends IValue> extends Writable<T> {
  * and updated whenever the value of the underlying setting is changed.
  * @param setting - a specific setting of the frontend
  */
-export function CreateSettingStore<T extends IValue>(setting:Setting<T>) : SettingStore<T> {
+export function CreateSettingStore<V extends IValue, S extends Setting<V>>(setting: S) : SettingStore<V,S> {
     const { subscribe, set, update } = writable(setting.Default);
 
     setting.ValueChanged.Subscribe(
-        (_: typeof setting, value: T) => set(value)
+        (_: typeof setting, value: V) => set(value)
     );
     return {
         subscribe,
         update,
-        set: (value: T) => { setting.Value = value; set(value); },
+        set: (value: V) => { setting.Value = value; set(value); },
         reset: () => { setting.Value = setting.Default; set(setting.Default); },
         setting : setting
     };
@@ -34,10 +34,10 @@ export function CreateSettingStore<T extends IValue>(setting:Setting<T>) : Setti
  * and updated whenever the value of the underlying setting is changed.
  * @param settingKey - an existing key (created in the engine)
  */
-export function CreateExistingSettingStore<T extends IValue>(settingKey: Key) : SettingStore<T> {
-    const setting: Setting<T> = globalsettings.Get(settingKey);
+export function CreateExistingSettingStore<V extends IValue, S extends Setting<V>>(settingKey: Key) : SettingStore<V,S> {
+    const setting: S = globalsettings.Get(settingKey);
     if (!setting) throw new Error(`Setting ${settingKey} does not exists`);
-    return CreateSettingStore<T>(setting);
+    return CreateSettingStore<V,S>(setting);
 }
 
 interface SettingCountStore extends Writable<number> {
@@ -52,9 +52,9 @@ interface SettingCountStore extends Writable<number> {
  * @param initialValue - value on creation
  * @param increment - step size when incrementing/decrementing
  * @param minimum - lowest value
- * @param maximum - highesrt value
+ * @param maximum - highest value
  */
-export function CreateCountStore(initialValue:number, increment:number,minimum = -Infinity, maximum = Infinity) : SettingCountStore {
+export function CreateCountStore(initialValue: number, increment: number,minimum = -Infinity, maximum = Infinity) : SettingCountStore {
     const { subscribe, set, update } = writable(initialValue);
 
     return {


### PR DESCRIPTION
Reworked Ronny's early svelte store implementation to feel more "svelte like" on usage
this can be seen here :
https://github.com/manga-download/haruneko/pull/117/files#diff-1b50d9a5d1ae3e40f8cbfdfb386679aa0b238bc033b49e14118622004e55a004L26-R24
where 
`    <Toggle
        toggled={$ContentPanelValue}
        on:toggle={(evt) => (ContentPanel.Value = evt.detail.toggled)}
    />`
becomes
` <Toggle bind:toggled={$ContentPanel} />`

Ended up with 2 helpers, one for the custom settings of the frontend, and one for the engine's ones
https://github.com/manga-download/haruneko/pull/117/files#diff-043205968d154e9ad9ffa00608ef5900128c29a75482eeca43072b9b7cc7db9e

Fusing both Setting and SettingValue lead to a small issues with the Choice kind (to get the available options) that I bypassed by casting (couldn't cast inline because of svelte)
https://github.com/manga-download/haruneko/pull/117/files#diff-1b50d9a5d1ae3e40f8cbfdfb386679aa0b238bc033b49e14118622004e55a004R14-R17
