### PR TITLE
Add FetchGraphQL to engine

### DIFF
--- a/web/src/engine/FetchProvider.ts
+++ b/web/src/engine/FetchProvider.ts
@@ -37,6 +37,11 @@ export function FetchCSS<T extends HTMLElement>(request: FetchRequest, query: st
     return fetchCSS<T>(request, query);
 }
 
+let fetchGraphQL: <TResult>(request: FetchRequest, operationName: string, query: string, variables : string) => Promise<TResult> = fail;
+export function FetchGraphQL<TResult>(request: FetchRequest, operationName: string, query: string, variables : string): Promise<TResult> {
+    return fetchGraphQL(request, operationName, query, variables);
+}
+
 let fetchWindowCSS: <T extends HTMLElement>(request: FetchRequest, query: string, delay: number, timeout?: number) => Promise<T[]> = fail;
 /**
  * Open the given {@link request} in a new browser window and execute the given {@link query}.
@@ -88,6 +93,7 @@ export function Initialize(info?: PlatformInfo): void {
         fetchWindowCSS = FetchProviderNodeWebkit.FetchWindowCSS;
         fetchWindowScript = FetchProviderNodeWebkit.FetchWindowScript;
         fetchWindowPreloadScript = FetchProviderNodeWebkit.FetchWindowPreloadScript;
+        fetchGraphQL = FetchProviderNodeWebkit.FetchGraphQL;
         return;
     }
 
@@ -101,6 +107,7 @@ export function Initialize(info?: PlatformInfo): void {
         fetchWindowCSS = FetchProviderBrowser.FetchWindowCSS;
         fetchWindowScript = FetchProviderBrowser.FetchWindowScript;
         fetchWindowPreloadScript = FetchProviderBrowser.FetchWindowPreloadScript;
+        fetchGraphQL = FetchProviderNodeWebkit.FetchGraphQL;
         return;
     }
 

--- a/web/src/engine/FetchProviderNodeWebkit.ts
+++ b/web/src/engine/FetchProviderNodeWebkit.ts
@@ -162,6 +162,11 @@ export async function FetchGraphQL<TResult>(request: FetchRequest, operationName
         headers: { 'content-type': 'application/json', 'accept': '*/*' }
     });
 
+    //copy custom headers from parent request
+    for (const header of request.headers) {
+        graphQLRequest.headers.set(header[0], header[1]);
+    }
+
     const data = await FetchJSON<GraphQLResult<TResult>>(graphQLRequest);
     if (data.errors && data.errors.length > 0) {
         throw new Error('errors: ' + data.errors.map(error => error.message).join('\n'));

--- a/web/src/engine/FetchProviderNodeWebkit.ts
+++ b/web/src/engine/FetchProviderNodeWebkit.ts
@@ -159,7 +159,7 @@ export async function FetchGraphQL<TResult>(request: FetchRequest, operationName
     const graphQLRequest = new FetchRequest(request.url, {
         body: JSON.stringify({ operationName, query, variables }),
         method: 'POST',
-        headers: { 'content/type': 'application/json' }
+        headers: { 'content-type': 'application/json', 'accept': '*/*' }
     });
 
     const data = await FetchJSON<GraphQLResult<TResult>>(graphQLRequest);
@@ -169,8 +169,7 @@ export async function FetchGraphQL<TResult>(request: FetchRequest, operationName
     if (!data.data) {
         throw new Error('No data available !');
     }
-
-    return data.data;
+    return data as TResult;
 }
 
 /*

--- a/web/src/engine/FetchProviderNodeWebkit.ts
+++ b/web/src/engine/FetchProviderNodeWebkit.ts
@@ -163,7 +163,7 @@ export async function FetchGraphQL<TResult>(request: FetchRequest, operationName
     });
 
     const data = await FetchJSON<GraphQLResult<TResult>>(graphQLRequest);
-    if (data.errors) {
+    if (data.errors && data.errors.length > 0) {
         throw new Error('errors: ' + data.errors.map(error => error.message).join('\n'));
     }
     if (!data.data) {


### PR DESCRIPTION
Its still WIP for 2 reasons : 

1) I added the `Accept` header because some websites (readerfront template) dont work without this value (in HaKUneko). I am testing the others . Currently, everything works fine.

2) i am not fond of passing a request as argument (like the other function) only to use the url part.

```
  const graphQLRequest = new FetchRequest(request.url, {
        body: JSON.stringify({ operationName, query, variables }),
        method: 'POST',
        headers: { 'content-type': 'application/json', 'accept': '*/*' }
    });
```

The thing is we have to force at least `content-type`, and  `FetchRequest `headers are read only.

Switch to an URL argument? 
Keep the FetchRequest argument, "cloning" it then apply our headers? 
Keep the FetchRequest argument, create our own graphQLRequest and apply custom headers from the argument FetchRequest but how? 



