### PR TITLE
fix FetchImageAjaxFromHTML

### DIFF
--- a/web/src/engine/websites/decorators/Common.ts
+++ b/web/src/engine/websites/decorators/Common.ts
@@ -546,9 +546,9 @@ export async function FetchImageAjaxFromHTML(this: MangaScraper, page: Page, pri
                 Referer: page.Link.origin,
             }
         });
-        const realimage = (await FetchCSS<HTMLImageElement>(request, queryImage))[0].src;
+        const realimage = (await FetchCSS<HTMLImageElement>(request, queryImage))[0].getAttribute('src');
         const parameters = page.Parameters?.Referer ? { Referer: page.Parameters?.Referer } : { Referer: page.Link.origin };
-        return new Page(this, page.Parent as Chapter, new URL(realimage, this.URI), parameters);
+        return new Page(this, page.Parent as Chapter, new URL(realimage, request.url), parameters);
     }, priority, signal);
 
     return await FetchImageAjax.call(this, image, priority, signal, detectMimeType, deProxifyLink);


### PR DESCRIPTION
* use getattribute('src') to avoid bad paths
* use request.url to build image url, like its done in other Page* decorators.

Every plugins using  this decorator has been confirmed working.