### PR TITLE
[comick] change domain & fix manga listing

### DIFF
--- a/web/src/engine/websites/ComicK.ts
+++ b/web/src/engine/websites/ComicK.ts
@@ -96,7 +96,7 @@ export default class extends DecoratableMangaScraper {
 
     private async _getMangasFromPage(page: number, provider: MangaPlugin): Promise<Manga[]>{
         try {
-            const uri = new URL(`v1.0/search?page=${page}&limit=49`, this.apiUrl); //adding a limit allows us to fetch all pages. 49 is the max
+            const uri = new URL(`v1.0/search?page=${page}&limit=49`, this.apiUrl);
             const request = new FetchRequest(uri.href);
             const data = await FetchJSON<APIManga[]>(request);
             return data.map(item => {

--- a/web/src/engine/websites/ComicK.ts
+++ b/web/src/engine/websites/ComicK.ts
@@ -65,10 +65,10 @@ const langMap = {
 
 export default class extends DecoratableMangaScraper {
 
-    private readonly apiUrl = 'https://api.comick.app';
+    private readonly apiUrl = 'https://api.comick.ink';
 
     public constructor() {
-        super('comick', `ComicK`, 'https://comick.app', Tags.Language.Multilingual, Tags.Media.Manga, Tags.Source.Aggregator);
+        super('comick', `ComicK`, 'https://comick.ink', Tags.Language.Multilingual, Tags.Media.Manga, Tags.Source.Aggregator);
     }
 
     public override get Icon() {
@@ -96,7 +96,7 @@ export default class extends DecoratableMangaScraper {
 
     private async _getMangasFromPage(page: number, provider: MangaPlugin): Promise<Manga[]>{
         try {
-            const uri = new URL('/v1.0/search?page=' + page, this.apiUrl);
+            const uri = new URL(`v1.0/search?page=${page}&limit=49`, this.apiUrl); //adding a limit allows us to fetch all pages. 49 is the max
             const request = new FetchRequest(uri.href);
             const data = await FetchJSON<APIManga[]>(request);
             return data.map(item => {

--- a/web/src/engine/websites/ComicK_e2e.ts
+++ b/web/src/engine/websites/ComicK_e2e.ts
@@ -6,7 +6,7 @@ const config: Config = {
         title: 'ComicK'
     },
     container: {
-        url: 'https://comick.app/comic/00-solo-leveling',
+        url: 'https://comick.ink/comic/00-solo-leveling',
         id: '71gMd0vF',
         title: 'Solo Leveling'
     },


### PR DESCRIPTION
adding a limit allows us to fetch all pages. 49 is the max