### PR TITLE
Filter C1 control chars from download path

### DIFF
--- a/web/src/engine/StorageController.ts
+++ b/web/src/engine/StorageController.ts
@@ -33,8 +33,20 @@ export function SanitizeFileName(name: string): string {
         '?': '？', // https://unicode-table.com/en/FF1F/, https://unicode-table.com/en/FE56/
         '*': '＊', // https://unicode-table.com/en/FF0A/
     };
-    //https://en.wikipedia.org/wiki/C0_and_C1_control_codes
-    return name.replace(/./g, c => c.charCodeAt(0) < 32 ? '' : c.charCodeAt(0) > 0x7E && c.charCodeAt(0) < 0xA0 ? '' : lookup[c] ?? c).replace(/[\s.]+$/, '').trim() || 'untitled';
+
+    // eslint-disable-next-line no-control-regex
+    const patternControlCharsUTF8 = /[\u0000-\u001F\u007F-\u009F]/gu; //https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+
+    if (patternControlCharsUTF8.test(name)) {
+        const sequenceCharsUTF8 = name.split('').map(c => c.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0'));
+        console.warn(`The filename '${name}' contains one or more invalid control characters which are going to be removed:`, sequenceCharsUTF8, '=>', name.match(patternControlCharsUTF8));
+    }
+
+    return name
+        .replace(patternControlCharsUTF8, '')
+        .replace(/./g, c => lookup[c] ?? c)
+        .replace(/[\s.]+$/, '')
+        .trim() || 'untitled';
 }
 
 /*

--- a/web/src/engine/StorageController.ts
+++ b/web/src/engine/StorageController.ts
@@ -33,7 +33,8 @@ export function SanitizeFileName(name: string): string {
         '?': '？', // https://unicode-table.com/en/FF1F/, https://unicode-table.com/en/FE56/
         '*': '＊', // https://unicode-table.com/en/FF0A/
     };
-    return name.replace(/./g, c => c.charCodeAt(0) < 32 ? '' : lookup[c] ?? c).replace(/[\s.]+$/, '').trim() || 'untitled';
+    //https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+    return name.replace(/./g, c => c.charCodeAt(0) < 32 ? '' : c.charCodeAt(0) > 0x7E && c.charCodeAt(0) < 0xA0 ? '' : lookup[c] ?? c).replace(/[\s.]+$/, '').trim() || 'untitled';
 }
 
 /*


### PR DESCRIPTION
Haruneko is partially affected by this file path sanitize problem https://github.com/manga-download/hakuneko/issues/6718.
It properly filter C0 chars but does nothing to C1 chars 

![sani1](https://github.com/manga-download/haruneko/assets/10671518/c6a8964e-887b-40b3-bf35-f5111f290312)
![sani2](https://github.com/manga-download/haruneko/assets/10671518/43023702-31ac-445e-a802-d67a98b7bb26)

Fixes properly remove x7F-x9F range  characters . x7F being DEL its invalid too, xA0 is NBSP and its valid.
