### PR TITLE
AlphaPolis : better manga listing / vertical mangas / other manga page layout

### DIFF
--- a/web/src/engine/websites/Alphapolis.ts
+++ b/web/src/engine/websites/Alphapolis.ts
@@ -1,6 +1,6 @@
 import { Tags } from '../Tags';
 import icon from './Alphapolis.webp';
-import { type Chapter, DecoratableMangaScraper, Page } from '../providers/MangaPlugin';
+import { type Chapter, DecoratableMangaScraper, Page, type MangaPlugin, type Manga } from '../providers/MangaPlugin';
 import * as Common from './decorators/Common';
 import { FetchCSS } from '../platform/FetchProvider';
 import type { Priority } from '../taskpool/TaskPool';
@@ -26,7 +26,6 @@ function ChaptersExtractor(element: HTMLDivElement) {
 }
 
 @Common.MangaCSS(/^{origin}\/manga\/official\/\d+/, 'div.manga-detail-description > div.title')
-@Common.MangasMultiPageCSS(`/manga/official/search?page={page}`, 'div.official-manga-panel > a', 1, 1, 0, MangaInfoExtractor)
 @Common.ChaptersSinglePageCSS('div.episode-unit', ChaptersExtractor)
 export default class extends DecoratableMangaScraper {
 
@@ -36,6 +35,11 @@ export default class extends DecoratableMangaScraper {
 
     public override get Icon() {
         return icon;
+    }
+
+    public override async FetchMangas(provider: MangaPlugin): Promise<Manga[]> {
+        const mangas = await Common.FetchMangasMultiPageCSS.call(this, provider, '/manga/official/search?page={page}', 'div.official-manga-panel > a', 1, 1, 0, MangaInfoExtractor);
+        return mangas.filter(manga => !manga.Title.endsWith('...'));//website truncate some manga name we cant do something clean about that => people will use clipboard for them
     }
 
     public override async FetchPages(chapter: Chapter): Promise<Page[]> {

--- a/web/src/engine/websites/Alphapolis_e2e.ts
+++ b/web/src/engine/websites/Alphapolis_e2e.ts
@@ -1,7 +1,7 @@
 ﻿import { describe } from 'vitest';
 import { TestFixture, type Config } from '../../../test/WebsitesFixture';
 
-const config: Config = {
+const configOfficial: Config = {
     plugin: {
         id: 'alphapolis',
         title: 'ALPHAPOLIS (アルファポリス)'
@@ -22,5 +22,29 @@ const config: Config = {
     }
 };
 
-const fixture = new TestFixture(config);
-describe(fixture.Name, async () => (await fixture.Connect()).AssertWebsite());
+const fixtureOfficial = new TestFixture(configOfficial);
+describe(fixtureOfficial.Name, async () => (await fixtureOfficial.Connect()).AssertWebsite());
+
+const configManga: Config = {
+    plugin: {
+        id: 'alphapolis',
+        title: 'ALPHAPOLIS (アルファポリス)'
+    },
+    container: {
+        url: 'https://www.alphapolis.co.jp/manga/853344814/118889164',
+        id: '/manga/853344814/118889164',
+        title: 'そのフラグをへし折りたい！'
+    },
+    child: {
+        id: '/manga/853344814/118889164/episode/8516663',
+        title: '闇に光るツーマンセル【1】'
+    },
+    entry: {
+        index: 0,
+        size: 217_919,
+        type: 'image/jpeg'
+    }
+};
+
+const fixtureManga = new TestFixture(configManga);
+describe(fixtureManga.Name, async () => (await fixtureManga.Connect()).AssertWebsite());


### PR DESCRIPTION
Closes https://github.com/manga-download/haruneko/issues/689

1. Fixes manga list

-  using `https://www.alphapolis.co.jp/manga/index?sort=recent&limit=1000&page=1` to get `/manga/12134/6465845` ones

-  using `https://www.alphapolis.co.jp/search?category=official_manga&query=A&page=1` to get `/manga/official/354564` ones

Those manga pages have a different layout, We handle both in clipboard too and when it comes to get chapters.

2. Fixed getting pages :

-  adjusted the regexp to both url types 
- adjusted page filters
- discovered that there are "vertical mangas". We do no replace page dimensions on those ones as we dont know the max one the websites provides.

3. Fixed fallback page download
 Turns out website throw a 403 error now  🤷 

