### PR TITLE
AsuraScans : support dynamic urls

### DIFF
--- a/web/src/engine/websites/AsuraScans.ts
+++ b/web/src/engine/websites/AsuraScans.ts
@@ -1,15 +1,9 @@
 import { Tags } from '../Tags';
 import icon from './AsuraScans.webp';
-import { type Chapter, DecoratableMangaScraper, Page, type Manga, type MangaPlugin } from '../providers/MangaPlugin';
+import { DecoratableMangaScraper, type Manga, type MangaPlugin } from '../providers/MangaPlugin';
 import * as MangaStream from './decorators/WordPressMangaStream';
 import * as Common from './decorators/Common';
-import { Fetch, FetchWindowScript } from '../platform/FetchProvider';
-
-type TSReader = Source[];
-
-type Source = {
-    images: string[];
-}
+import { FetchWindowScript } from '../platform/FetchProvider';
 
 const excludes = [
     /panda_gif_large/i,
@@ -19,13 +13,31 @@ const excludes = [
     /EndDesignPSD/i
 ];
 
-@MangaStream.MangasSinglePageCSS()
-@MangaStream.ChaptersSinglePageCSS()
+function MangaInfoExtractor(anchor: HTMLAnchorElement) {
+    return {
+        id: anchor.pathname.replace(/-[^-]+$/, '-'),
+        title: anchor.querySelector('div.items-center span.font-bold').textContent.trim()
+    };
+}
+
+const chapterScript = `
+    new Promise (resolve => {
+        resolve([...document.querySelectorAll('div.scrollbar-thumb-themecolor a.block')].map(link => {
+            return {
+                id: link.pathname.replace(/-[^-]+(\\/chapter)/, '-$1'),
+                title : link.querySelector('div > h3').textContent.trim()
+            };
+        }));
+    });
+`;
+@Common.MangasMultiPageCSS('/series?page={page}', 'div.grid a', 1, 1, 0, MangaInfoExtractor)
+@Common.ChaptersSinglePageJS(chapterScript)
+@MangaStream.PagesSinglePageCSS(excludes, 'img[alt="chapter"]')
 @Common.ImageAjax()
 export default class extends DecoratableMangaScraper {
 
     public constructor() {
-        super('asurascans', 'Asura Scans', 'https://asuratoon.com', Tags.Media.Manhwa, Tags.Media.Manhua, Tags.Language.English, Tags.Source.Scanlator);
+        super('asurascans', 'Asura Scans', 'https://asuracomic.net', Tags.Media.Manhwa, Tags.Media.Manhua, Tags.Language.English, Tags.Source.Scanlator);
     }
 
     public override get Icon() {
@@ -33,29 +45,14 @@ export default class extends DecoratableMangaScraper {
     }
 
     public override async Initialize(): Promise<void> {
-        const request = new Request(this.URI.href);
-        this.URI.href = await FetchWindowScript<string>(request, 'window.location.origin');
+        this.URI.href = await FetchWindowScript<string>(new Request(this.URI), 'window.location.origin');
     }
 
     public override ValidateMangaURL(url: string): boolean {
-        return new RegExp(`^${this.URI.origin}/manga/[^/]+/$`).test(url);
+        return new RegExp(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 
     public override async FetchManga(this: DecoratableMangaScraper, provider: MangaPlugin, url: string): Promise<Manga> {
-        return MangaStream.FetchMangaCSS.call(this, provider, url);
-    }
-
-    public override async FetchPages(chapter: Chapter): Promise<Page[]> {
-        let images: string[] = [];
-        try {
-            const response = await Fetch(new Request(new URL(chapter.Identifier, this.URI).href));
-            const data = await response.text();
-            const tsreader: TSReader = JSON.parse(data.match(/"sources":(\[[^;]+\]}\])/m)[1]);
-            images = tsreader.shift().images.filter(link => !excludes.some(rgx => rgx.test(link)));
-            return images.map(image => new Page(this, chapter, new URL(image)));
-        } catch (error) {
-            return MangaStream.FetchPagesSinglePageCSS.call(this, chapter, excludes, 'div#readerarea p img');
-        }
-
+        return MangaStream.FetchMangaCSS.call(this, provider, url.replace(/-[^-]+$/, '-'), 'div.bg-white div.relative span.text-xl.font-bold');
     }
 }

--- a/web/src/engine/websites/AsuraScans_e2e.ts
+++ b/web/src/engine/websites/AsuraScans_e2e.ts
@@ -7,17 +7,17 @@ const config: Config = {
         title: 'Asura Scans',
     },
     container: {
-        url: 'https://asuratoon.com/manga/0308950452-dragon-devouring-mage/',
-        id: '/manga/0308950452-dragon-devouring-mage/',
+        url: 'https://asuracomic.net/series/dragon-devouring-mage-f4dac81c',
+        id: '/series/dragon-devouring-mage-',
         title: 'Dragon-Devouring Mage',
     },
     child: {
-        id: '/4460228866-dragon-devouring-mage-1/',
+        id: '/series/dragon-devouring-mage-/chapter/1',
         title: 'Chapter 1',
     },
     entry: {
         index: 1,
-        size: 4_377_432,
+        size: 859_466,
         type: 'image/jpeg'
     }
 };


### PR DESCRIPTION
All asura mangas have dynamic suffixes : 

i.e `https://asuracomic.net/series/logging-10000-years-into-the-future-a6c802df`
Trying to fetch `https://asuracomic.net/series/logging-10000-years-into-the-future-` redirect automatically to the suffixed page.

We are just stripping the dynamic part of the url and rely on website redirection.

For chapters, using directly anchors pathnames would miss the "/series/" in path as links are relatives.

![image](https://github.com/user-attachments/assets/42078006-957f-4d31-b3ee-e7158e7e1e77)



