### PR TITLE
Replace jsPDF with PDFKit

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,8 +6,8 @@
         "npm": ">=10.2.4"
     },
     "dependencies": {
-        "jspdf": "^2.5.2",
         "jszip": "^3.10.1",
+        "pdfkit": "github:manga-download/pdfkit#v0.15.1",
         "protobufjs": "^7.4.0"
     },
     "devDependencies": {

--- a/web/src/engine/exporters/PortableDocumentFormatExporter.ts
+++ b/web/src/engine/exporters/PortableDocumentFormatExporter.ts
@@ -1,4 +1,4 @@
-import jsPDF from 'jspdf';
+import PDFDocument from 'pdfkit';
 import { MangaExporter } from './MangaExporter';
 import { SanitizeFileName } from '../StorageController';
 import { Priority, TaskPool } from '../taskpool/TaskPool';
@@ -16,11 +16,12 @@ export class PortableDocumentFormatExporter extends MangaExporter {
             const { data } = await super.ReadTempImageData(sourceFileList.get(index), index, digits);
             const bitmap = await createImageBitmap(data);
             try {
-                const { width, height } = bitmap;
-                // Conversion of unsupported images via jsPDF is slow and produces a large PDF => Using own implementation of image conversion
-                let buffer = new Uint8Array(await data.arrayBuffer());
-                buffer = await this.CheckImageCompatibility(data.type, buffer) ? buffer : new Uint8Array(await (await ConvertBitmap(bitmap, 'image/jpeg', 0.95)).arrayBuffer());
-                return { width, height, data: buffer };
+                return {
+                    width: bitmap.width,
+                    height: bitmap.height,
+                    // Conversion of unsupported images via jsPDF is slow and produces a large PDF => Using own implementation of image conversion
+                    data: pdfImageFormats.includes(data.type) ? data : await ConvertBitmap(bitmap, 'image/jpeg', 0.95)
+                };
             } finally {
                 bitmap.close();
             }
@@ -28,46 +29,31 @@ export class PortableDocumentFormatExporter extends MangaExporter {
         return Promise.all(promises);
     }
 
-    private async CheckImageCompatibility(mimetype: string, buffer: Uint8Array): Promise<boolean> {
-        return mimetype === 'image/jpeg' ? this.IsCompatibleJPEG(buffer) : pdfImageFormats.includes(mimetype);
-    }
-
-    /**
-     * Test if JPEG data is compatible with JsPDF "headers check"
-     * @param imageData - Image buffer as Uint8Array
-     * @returns
-     */
-    private async IsCompatibleJPEG(imageData: Uint8Array): Promise<boolean> {
-        const jsPdfJpegHeaders =
-            [[0xff, 0xd8, 0xff, 0xe0, undefined, undefined, 0x4a, 0x46, 0x49, 0x46, 0x00], //JFIF
-                [0xff, 0xd8, 0xff, 0xe1, undefined, undefined, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00], //Exif
-                [0xff, 0xd8, 0xff, 0xdb], //JPEG RAW
-                [0xff, 0xd8, 0xff, 0xee] //EXIF RAW
-            ];
-
-        return jsPdfJpegHeaders.some(jpegPattern => {
-            for (let index = 0; index < jpegPattern.length; index++) {
-                if (jpegPattern[index] !== undefined && jpegPattern[index] !== imageData[index]) {
-                    return false;
-                }
-            }
-            return true;
-        });
-    }
-
     public async Export(sourceFileList: Map<number, string>, targetDirectory: FileSystemDirectoryHandle, targetBaseName: string): Promise<void> {
-        const pdf = new jsPDF({ unit: 'px' });
-        pdf.deletePage(1);
+        const file = await targetDirectory.getFileHandle(SanitizeFileName(targetBaseName + '.pdf'), { create: true });
+        const stream = await file.createWritable();
+        const pdf = new PDFDocument({
+            autoFirstPage: false,
+            compress: false,
+            margin: 0,
+        });
+        pdf.on('data', (bytes: Uint8Array) => stream.write(bytes));
+        pdf.once('error', () => stream.close());
+        pdf.once('end', () => stream.close());
 
         for(const { width, height, data } of await this.PrepareImages(sourceFileList)) {
             const pageHeight = height * pageWidth / width;
-            pdf.addPage([ pageWidth, pageHeight ], pageWidth < pageHeight ? 'portrait': 'landscape');
-            pdf.addImage(data, 0, 0, pageWidth, pageHeight);
+            pdf.addPage({
+                layout: pageWidth < pageHeight ? 'portrait': 'landscape',
+                size: [ pageWidth, pageHeight ],
+                margin: 0,
+            }).image(await data.arrayBuffer(), {
+                fit: [ pageWidth, pageHeight ],
+                valign: 'center',
+                align: 'center',
+            });
         }
 
-        const file = await targetDirectory.getFileHandle(SanitizeFileName(targetBaseName + '.pdf'), { create: true });
-        const stream = await file.createWritable();
-        await stream.write(pdf.output('blob'));
-        await stream.close();
+        pdf.end();
     }
 }


### PR DESCRIPTION
Seems to have better support for a wider range of different JPEG flavors (#797)

## Bundle with jsPDF

![HaruNeko - jsPDF](https://github.com/user-attachments/assets/55c938db-3f6a-4f22-ab2b-349d54f003f7)

## Bundle with PDFKit

![HaruNeko - PDFKit](https://github.com/user-attachments/assets/42995f1d-029d-48e3-83cd-43e764a239a6)