### PR TITLE
fix the u_ error in prod

### DIFF
--- a/web/src/engine/Error.ts
+++ b/web/src/engine/Error.ts
@@ -14,7 +14,11 @@ export class InternalError extends Error {
 /**
  * An error indicating that a certain programming logic is intentionally missing.
  */
-export /* sealed */ class NotImplementedError extends InternalError {}
+export /* sealed */ class NotImplementedError extends InternalError {
+    public override get name(): string {
+        return "NotImplementedError";
+    }
+}
 
 /**
  * An exception should be raised when a problem appears during runtime and should be properly handled at some point.


### PR DESCRIPTION
it gets minified in prod so you cant use this.constructor.name;

if you dont want to have to do this then you could also just add 
```
esbuild: {
    keepNames: true
}
```
to the vite.config.ts in web instead

#867 does that