### PR TITLE
u_ error fix using keepNames

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -40,5 +40,8 @@ export default defineConfig({
         include: ['carbon-components-svelte'],
         // carbon-icons-svelte is huge and takes 12s to prebundle, better use deep imports for the icons you need
         exclude: ['carbon-icons-svelte']
+    },
+    esbuild: {
+        keepNames: true
     }
 });


### PR DESCRIPTION
this or #866
either works

this will make the bundle larger. but it means you don't gotta think about name whenever you extend the InternalError class