### PR TITLE
Make ValidateMangaUrl async

### DIFF
--- a/docs/development-guide/tutorials/add-website.md
+++ b/docs/development-guide/tutorials/add-website.md
@@ -101,7 +101,7 @@ export default class extends DecoratableMangaScraper {
 
     /* Other Implementations */
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return url.startsWith(this.URI + '/manga/');
     }
 

--- a/web/src/engine/providers/MangaPlugin.ts
+++ b/web/src/engine/providers/MangaPlugin.ts
@@ -25,7 +25,7 @@ export abstract class MangaScraper extends MediaScraper<MangaPlugin> {
         return new MangaPlugin(storageController, settingsManager, this);
     }
 
-    public abstract ValidateMangaURL(url: string): boolean;
+    public abstract ValidateMangaURL(url: string): Promise<boolean>;
     public abstract FetchManga(provider: MangaPlugin, url: string): Promise<Manga>;
     public abstract FetchMangas(provider: MangaPlugin): Promise<Manga[]>;
     public abstract FetchChapters(manga: Manga): Promise<Chapter[]>;
@@ -39,8 +39,8 @@ export abstract class MangaScraper extends MediaScraper<MangaPlugin> {
  */
 export class DecoratableMangaScraper extends MangaScraper {
 
-    public ValidateMangaURL(_url: string): boolean {
-        return false;
+    public ValidateMangaURL(_url: string): Promise<boolean> {
+        return Promise.resolve(false);
     }
 
     public FetchManga(_provider: MangaPlugin, _url: string): Promise<Manga> {
@@ -103,7 +103,7 @@ export class MangaPlugin extends MediaContainer<Manga> {
     }
 
     public override async TryGetEntry(url: string): Promise<Manga> {
-        if(this.scraper.ValidateMangaURL(url)) {
+        if(await this.scraper.ValidateMangaURL(url)) {
             await this.Initialize();
             const manga = await this.scraper.FetchManga(this, url);
             return this.Entries.Value.find((entry) => entry.IsSameAs(manga)) ?? manga;

--- a/web/src/engine/websites/AsuraScans.ts
+++ b/web/src/engine/websites/AsuraScans.ts
@@ -37,7 +37,7 @@ export default class extends DecoratableMangaScraper {
         this.URI.href = await FetchWindowScript<string>(new Request(this.URI), 'window.location.origin');
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/CiaoPlus.ts
+++ b/web/src/engine/websites/CiaoPlus.ts
@@ -46,7 +46,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comics/title/\\d+/episode/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/ColoredManga.ts
+++ b/web/src/engine/websites/ColoredManga.ts
@@ -49,7 +49,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/ComicFans.ts
+++ b/web/src/engine/websites/ComicFans.ts
@@ -47,7 +47,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /https:\/\/(comicfans\.io|bilibilicomics\.net)\/comic\/\d+-[^/]+$/.test(url);
     }
 

--- a/web/src/engine/websites/ComicFuz.ts
+++ b/web/src/engine/websites/ComicFuz.ts
@@ -64,9 +64,8 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/\\d+$`).test(url);
-
     }
 
     public override async FetchManga(provider: MangaPlugin, url: string): Promise<Manga> {

--- a/web/src/engine/websites/ComicK.ts
+++ b/web/src/engine/websites/ComicK.ts
@@ -71,7 +71,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /https:\/\/comick\.(io|cc|app|ink)\/comic\/[^/]+$/.test(url);
     }
 

--- a/web/src/engine/websites/ComicZerosum.ts
+++ b/web/src/engine/websites/ComicZerosum.ts
@@ -46,7 +46,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/detail/`).test(url);
     }
 

--- a/web/src/engine/websites/Comico.ts
+++ b/web/src/engine/websites/Comico.ts
@@ -87,7 +87,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/\\S+/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/ComikeyArchive.d.ts
+++ b/web/src/engine/websites/ComikeyArchive.d.ts
@@ -5,7 +5,7 @@ export default class extends DecoratableMangaScraper {
     constructor();
     get Icon(): string;
     Initialize(): Promise<void>;
-    ValidateMangaURL(url: string): boolean;
+    ValidateMangaURL(url: string): Promise<boolean>;
     FetchManga(provider: MangaPlugin, url: string): Promise<Manga>;
     FetchMangas(provider: MangaPlugin): Promise<Manga[]>;
     FetchChapters(manga: Manga): Promise<Chapter[]>;

--- a/web/src/engine/websites/CookMana.ts
+++ b/web/src/engine/websites/CookMana.ts
@@ -37,7 +37,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/episode/\\d+/1/1$`).test(url);
     }
 

--- a/web/src/engine/websites/CopyManga.ts
+++ b/web/src/engine/websites/CopyManga.ts
@@ -55,7 +55,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/[^/]+$`).test(url) || /^https:\/\/www\.mangacopy\.com\/comic\/[^/]+$/.test(url);
     }
 

--- a/web/src/engine/websites/CuuTruyen.ts
+++ b/web/src/engine/websites/CuuTruyen.ts
@@ -52,7 +52,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExp(`^${this.URI.origin}/mangas/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/CyComi.ts
+++ b/web/src/engine/websites/CyComi.ts
@@ -70,7 +70,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/title/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/DayComics.ts
+++ b/web/src/engine/websites/DayComics.ts
@@ -99,7 +99,7 @@ export default class extends DecoratableMangaScraper {
         return FetchWindowScript(new Request(this.URI), matureCookieScript, 500);
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/content/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/Digimon.ts
+++ b/web/src/engine/websites/Digimon.ts
@@ -29,7 +29,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/digimoncomic/(en/)?#`).test(url);
     }
 

--- a/web/src/engine/websites/DisasterScans.ts
+++ b/web/src/engine/websites/DisasterScans.ts
@@ -56,7 +56,7 @@ export default class extends DecoratableMangaScraper {
         this.nextBuild = data.buildId;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comics/[^/]+`).test(url);
     }
 

--- a/web/src/engine/websites/Dmzj.ts
+++ b/web/src/engine/websites/Dmzj.ts
@@ -55,7 +55,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string) {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/info/\\S+.html$`).test(url);
     }
 

--- a/web/src/engine/websites/GalaxyManga.ts
+++ b/web/src/engine/websites/GalaxyManga.ts
@@ -2,6 +2,7 @@ import { Tags } from '../Tags';
 import icon from './GalaxyManga.webp';
 import { DecoratableMangaScraper, type MangaPlugin, type Manga } from '../providers/MangaPlugin';
 import * as Common from './decorators/Common';
+import { FetchCSS } from '../platform/FetchProvider';
 
 function ChapterInfoExtractor(element: HTMLAnchorElement) {
     return {
@@ -10,18 +11,40 @@ function ChapterInfoExtractor(element: HTMLAnchorElement) {
     };
 }
 
-@Common.MangaCSS(/^{origin}\/series\/\d+-\d+-[^/]+$/, 'main section > div > div.font-semibold')
 @Common.ChaptersSinglePageCSS('main section div.overflow-y-auto div.grid > a', ChapterInfoExtractor)
 @Common.PagesSinglePageCSS('main > section > div > img')
 @Common.ImageAjax()
 export default class extends DecoratableMangaScraper {
+    private domainUpdated = false;
+    private readonly mangapattern = /^{origin}\/series\/\d+-\d+-[^/]+$/;
 
     public constructor() {
-        super('galaxymanga', 'Galaxy Manga', 'https://galaxymanga.net', Tags.Media.Manga, Tags.Media.Manhwa, Tags.Media.Manhua, Tags.Language.Arabic, Tags.Source.Scanlator);
+        super('galaxymanga', 'Galaxy Manga', 'https://outdatedwebsite.net', Tags.Media.Manga, Tags.Media.Manhwa, Tags.Media.Manhua, Tags.Language.Arabic, Tags.Source.Scanlator);
     }
 
     public override get Icon() {
         return icon;
+    }
+
+    private async DomainUpdate(): Promise<void> {
+        if (this.domainUpdated) return;
+        const [element] = await FetchCSS(new Request('https://gxcomic.xyz'), 'div.container p strong');
+        this.URI.href = element ? element.textContent.startsWith('https://') ? element.textContent.trim() : `https://${element.textContent.trim()}` : this.URI.href;
+        this.domainUpdated = true;
+    }
+
+    public override async Initialize(): Promise<void> {
+        await this.DomainUpdate();
+    }
+
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
+        await this.DomainUpdate();
+        const source = this.mangapattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
+        return new RegExpSafe(source, this.mangapattern.flags).test(url);
+    }
+
+    public override async FetchManga(provider: MangaPlugin, url: string): Promise<Manga> {
+        return Common.FetchMangaCSS.call(this, provider, url, 'main section > div > div.font-semibold');
     }
 
     public override async FetchMangas(provider: MangaPlugin): Promise<Manga[]> {

--- a/web/src/engine/websites/GanGanOnline.ts
+++ b/web/src/engine/websites/GanGanOnline.ts
@@ -56,7 +56,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/title/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/Ganma.ts
+++ b/web/src/engine/websites/Ganma.ts
@@ -50,7 +50,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/HentaiHand.ts
+++ b/web/src/engine/websites/HentaiHand.ts
@@ -26,7 +26,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/en/`).test(url);
     }
 

--- a/web/src/engine/websites/HentaiWebtoon.ts
+++ b/web/src/engine/websites/HentaiWebtoon.ts
@@ -12,7 +12,7 @@ export default class extends ManhwaHentaiMe {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/[^/]+\/$`).test(url);
     }
 }

--- a/web/src/engine/websites/Hitomi.ts
+++ b/web/src/engine/websites/Hitomi.ts
@@ -24,7 +24,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+/[^/]+-\\d+.html(#\\d*)?$`).test(url);
     }
 

--- a/web/src/engine/websites/HqNow.ts
+++ b/web/src/engine/websites/HqNow.ts
@@ -43,7 +43,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/hq/[\\d]+`).test(url);
     }
 

--- a/web/src/engine/websites/Imgur.ts
+++ b/web/src/engine/websites/Imgur.ts
@@ -32,7 +32,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/gallery/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/InManga.ts
+++ b/web/src/engine/websites/InManga.ts
@@ -37,7 +37,7 @@ export default class extends DecoratableMangaScraper {
         return request;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/ver/`).test(url);
     }
 

--- a/web/src/engine/websites/KadoComi.ts
+++ b/web/src/engine/websites/KadoComi.ts
@@ -57,7 +57,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/detail/[^/]+`).test(url);
     }
 

--- a/web/src/engine/websites/Kakaopage.ts
+++ b/web/src/engine/websites/Kakaopage.ts
@@ -44,7 +44,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/content/[\\d]+$`).test(url);
     }
 

--- a/web/src/engine/websites/KuManga.ts
+++ b/web/src/engine/websites/KuManga.ts
@@ -43,7 +43,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/\\d+/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/Kuaikanmanhua.ts
+++ b/web/src/engine/websites/Kuaikanmanhua.ts
@@ -58,7 +58,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /^https?:\/\/(m\.|www\.)?kuaikanmanhua\.com\/(mobile|web\/topic)\/\d+\//.test(url);
     }
 

--- a/web/src/engine/websites/Luscious.ts
+++ b/web/src/engine/websites/Luscious.ts
@@ -48,7 +48,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/albums/`).test(url);
     }
 

--- a/web/src/engine/websites/MangaCross.ts
+++ b/web/src/engine/websites/MangaCross.ts
@@ -48,7 +48,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+/$`).test(url);
     }
 

--- a/web/src/engine/websites/MangaDex.ts
+++ b/web/src/engine/websites/MangaDex.ts
@@ -109,7 +109,7 @@ export default class extends MangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/title/`).test(url);
     }
 

--- a/web/src/engine/websites/MangaFreak.ts
+++ b/web/src/engine/websites/MangaFreak.ts
@@ -23,7 +23,7 @@ export default class extends DecoratableMangaScraper {
         console.log(`Assigned URL '${this.URI}' to ${this.Title}`);
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /https?:\/\/w+\d*.mangafreak.me\/Manga\/[^/]+$/.test(url);
     }
 

--- a/web/src/engine/websites/MangaHot.ts
+++ b/web/src/engine/websites/MangaHot.ts
@@ -33,7 +33,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         const uri = new URL(url);
         return uri.origin === this.URI.origin && uri.pathname === '/works/detail.php' && uri.searchParams.has('work_code');
     }

--- a/web/src/engine/websites/MangaRomance.ts
+++ b/web/src/engine/websites/MangaRomance.ts
@@ -36,7 +36,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/search/label/[^?]+$`).test(this.StripSearch(url));
     }
 

--- a/web/src/engine/websites/MangaTales.ts
+++ b/web/src/engine/websites/MangaTales.ts
@@ -103,7 +103,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/mangas/\\d+/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/MangaTube.ts
+++ b/web/src/engine/websites/MangaTube.ts
@@ -56,7 +56,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/MangaUpGlobal.ts
+++ b/web/src/engine/websites/MangaUpGlobal.ts
@@ -45,7 +45,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/[\\d]+$`).test(url);
     }
 

--- a/web/src/engine/websites/Mangabox.ts
+++ b/web/src/engine/websites/Mangabox.ts
@@ -23,7 +23,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/reader/\\d+/episodes/$`).test(url);
     }
 

--- a/web/src/engine/websites/Mangadon.ts
+++ b/web/src/engine/websites/Mangadon.ts
@@ -51,7 +51,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/catalogs/show\\?tb=\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/Mangazure.ts
+++ b/web/src/engine/websites/Mangazure.ts
@@ -57,7 +57,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/\\d{4}/\\d+/[^/]+.html$`).test(url);
     }
 

--- a/web/src/engine/websites/Manhwa68.ts
+++ b/web/src/engine/websites/Manhwa68.ts
@@ -17,7 +17,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/[^/]+/$`).test(url);
     }
 

--- a/web/src/engine/websites/ManhwaHentaiMe.ts
+++ b/web/src/engine/websites/ManhwaHentaiMe.ts
@@ -38,7 +38,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/webtoon/[^/]+\/$`).test(url);
     }
 

--- a/web/src/engine/websites/ManhwaWeb.ts
+++ b/web/src/engine/websites/ManhwaWeb.ts
@@ -37,7 +37,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/(manga|manhwa)/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/ManyToon.ts
+++ b/web/src/engine/websites/ManyToon.ts
@@ -12,7 +12,7 @@ export default class extends ManhwaHentaiMe {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manhwa/[^/]+\/$`).test(url);
     }
 }

--- a/web/src/engine/websites/ManyToonCOM.ts
+++ b/web/src/engine/websites/ManyToonCOM.ts
@@ -12,7 +12,7 @@ export default class extends ManhwaHentaiMe {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/[^/]+\/$`).test(url);
     }
 }

--- a/web/src/engine/websites/ManyToonKR.ts
+++ b/web/src/engine/websites/ManyToonKR.ts
@@ -12,7 +12,7 @@ export default class extends ManhwaHentaiMe {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manhwa-raw/[^/]+\/$`).test(url);
     }
 

--- a/web/src/engine/websites/MonochromeScans.ts
+++ b/web/src/engine/websites/MonochromeScans.ts
@@ -36,7 +36,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/`).test(url);
     }
 

--- a/web/src/engine/websites/MultPorn.ts
+++ b/web/src/engine/websites/MultPorn.ts
@@ -47,7 +47,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/(${categories.join('|')})/[^/]+`).test(url);
     }
 

--- a/web/src/engine/websites/NHentaiCom.ts
+++ b/web/src/engine/websites/NHentaiCom.ts
@@ -28,7 +28,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+/comic/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/NamiComi.ts
+++ b/web/src/engine/websites/NamiComi.ts
@@ -51,7 +51,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+/title/[^/]+/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/NetComics.ts
+++ b/web/src/engine/websites/NetComics.ts
@@ -50,7 +50,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /https:\/\/www\.netcomics\.com\/[a-z]{2}\/comic\/[^/]+/.test(url);
     }
 

--- a/web/src/engine/websites/NicoNicoSeiga.ts
+++ b/web/src/engine/websites/NicoNicoSeiga.ts
@@ -49,7 +49,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^https://(sp.)?manga.nicovideo.jp/comic/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/NovelMic.ts
+++ b/web/src/engine/websites/NovelMic.ts
@@ -16,7 +16,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/[^/]+/$`).test(url);
     }
 

--- a/web/src/engine/websites/OlympusScanlation.ts
+++ b/web/src/engine/websites/OlympusScanlation.ts
@@ -55,7 +55,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/`).test(url);
     }
 

--- a/web/src/engine/websites/Penlab.ts
+++ b/web/src/engine/websites/Penlab.ts
@@ -75,7 +75,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/titles/\\S+/$`).test(url);
     }
 

--- a/web/src/engine/websites/Piccoma.ts
+++ b/web/src/engine/websites/Piccoma.ts
@@ -44,7 +44,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExp('^https://(jp\\.)?piccoma.com/web/product/\\d+').test(url);
     }
 

--- a/web/src/engine/websites/PixivComics.ts
+++ b/web/src/engine/websites/PixivComics.ts
@@ -80,7 +80,7 @@ export default class extends DecoratableMangaScraper {
         this.nextBuild = await FetchWindowScript(new Request(new URL(this.URI)), `__NEXT_DATA__.buildId`, 2500) ?? this.nextBuild;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/works/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/PocketComics.ts
+++ b/web/src/engine/websites/PocketComics.ts
@@ -31,7 +31,7 @@ export default class extends Comico {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/RawDevart.ts
+++ b/web/src/engine/websites/RawDevart.ts
@@ -43,7 +43,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+-c\\d+`).test(url);
     }
 

--- a/web/src/engine/websites/RawXZ.ts
+++ b/web/src/engine/websites/RawXZ.ts
@@ -22,7 +22,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/[^/]+/$`).test(url);
     }
 

--- a/web/src/engine/websites/ReaperScans.ts
+++ b/web/src/engine/websites/ReaperScans.ts
@@ -45,7 +45,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/RidiBooks.ts
+++ b/web/src/engine/websites/RidiBooks.ts
@@ -55,7 +55,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/books/\\d+`).test(url);
     }
 

--- a/web/src/engine/websites/RuManhua.ts
+++ b/web/src/engine/websites/RuManhua.ts
@@ -32,7 +32,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+/$`).test(url);
     }
 

--- a/web/src/engine/websites/SenManga.ts
+++ b/web/src/engine/websites/SenManga.ts
@@ -59,7 +59,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/title/`).test(url);
     }
 

--- a/web/src/engine/websites/SheepManga.ts
+++ b/web/src/engine/websites/SheepManga.ts
@@ -23,7 +23,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /\/sheep-scanlations\/\d+\.json/.test(url);
     }
 

--- a/web/src/engine/websites/SheepMangaBroken.ts
+++ b/web/src/engine/websites/SheepMangaBroken.ts
@@ -18,7 +18,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return /\/sheep-scanlations-broken\/\d+\.json/.test(url);
     }
 

--- a/web/src/engine/websites/ShueishaMangaPlus.ts
+++ b/web/src/engine/websites/ShueishaMangaPlus.ts
@@ -74,7 +74,7 @@ export default class extends DecoratableMangaScraper {
         return languages[language] || '[en]';
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/titles/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/SoftKomik.ts
+++ b/web/src/engine/websites/SoftKomik.ts
@@ -57,7 +57,7 @@ export default class extends DecoratableMangaScraper {
         this.nextBuild = await FetchWindowScript<string>(request, `__NEXT_DATA__.buildId`, 5000);
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/Sukima.ts
+++ b/web/src/engine/websites/Sukima.ts
@@ -71,7 +71,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/book/title/[^/]+/$`).test(url);
     }
 

--- a/web/src/engine/websites/Tapas.ts
+++ b/web/src/engine/websites/Tapas.ts
@@ -45,7 +45,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/TappyToon.ts
+++ b/web/src/engine/websites/TappyToon.ts
@@ -69,7 +69,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/[a-z]{2}/book/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/Tapread.ts
+++ b/web/src/engine/websites/Tapread.ts
@@ -47,7 +47,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/detail/`).test(url);
     }
 

--- a/web/src/engine/websites/Team1x1.ts
+++ b/web/src/engine/websites/Team1x1.ts
@@ -26,7 +26,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/TempleScan.ts
+++ b/web/src/engine/websites/TempleScan.ts
@@ -35,7 +35,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/ToCoronaEx.ts
+++ b/web/src/engine/websites/ToCoronaEx.ts
@@ -42,7 +42,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comics/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/TruyenQQ.ts
+++ b/web/src/engine/websites/TruyenQQ.ts
@@ -32,7 +32,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/truyen-tranh/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/TsukiMangas.ts
+++ b/web/src/engine/websites/TsukiMangas.ts
@@ -39,7 +39,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExp(`^${this.URI.origin}/obra/\\d+/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/TurkManga.ts
+++ b/web/src/engine/websites/TurkManga.ts
@@ -54,7 +54,7 @@ export default class extends DecoratableMangaScraper {
         this.nextBuild = await FetchWindowScript<string>(new Request(this.URI), `__NEXT_DATA__.buildId`, 2500);
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/VortexScans.ts
+++ b/web/src/engine/websites/VortexScans.ts
@@ -46,7 +46,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/series/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/WebAce.ts
+++ b/web/src/engine/websites/WebAce.ts
@@ -21,7 +21,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         // NOTE: only mangas with ID >= 1000000 have chapters for online reading
         return new RegExpSafe(`^${this.URI.origin}/[^/]+/contents/\\d{7}/`).test(url);
     }

--- a/web/src/engine/websites/WebComicsApp.ts
+++ b/web/src/engine/websites/WebComicsApp.ts
@@ -46,7 +46,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/`).test(url);
     }
 

--- a/web/src/engine/websites/WebNovel.ts
+++ b/web/src/engine/websites/WebNovel.ts
@@ -54,7 +54,7 @@ export default class extends DecoratableMangaScraper {
         this.token = data;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comic/\\S+_\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/WeiboManhua.ts
+++ b/web/src/engine/websites/WeiboManhua.ts
@@ -68,7 +68,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/c/`).test(url);
     }
 

--- a/web/src/engine/websites/Ynjn.ts
+++ b/web/src/engine/websites/Ynjn.ts
@@ -45,7 +45,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/title/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/Yurineko.ts
+++ b/web/src/engine/websites/Yurineko.ts
@@ -28,7 +28,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/manga/\\d+$`).test(url);
     }
 

--- a/web/src/engine/websites/Zebrack.ts
+++ b/web/src/engine/websites/Zebrack.ts
@@ -110,7 +110,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/(title|gravure|magazine)/\\d+(/(issue|volume|volume_list)/\\d+)?`).test(url);
     }
 

--- a/web/src/engine/websites/ZeroScans.ts
+++ b/web/src/engine/websites/ZeroScans.ts
@@ -44,7 +44,7 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/comics/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/decorators/Common.ts
+++ b/web/src/engine/websites/decorators/Common.ts
@@ -126,7 +126,7 @@ export function MangaCSS(pattern: RegExp, query: string, extract = DefaultLabelE
     return function DecorateClass<T extends Constructor>(ctor: T, context?: ClassDecoratorContext): T {
         ThrowOnUnsupportedDecoratorContext(context);
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(this: MangaScraper, url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/decorators/FoolSlide.ts
+++ b/web/src/engine/websites/decorators/FoolSlide.ts
@@ -49,7 +49,7 @@ export function MangaCSS(pattern: RegExp, query: string = queryMangaTitle) {
     return function DecorateClass<T extends Common.Constructor>(ctor: T, context?: ClassDecoratorContext): T {
         Common.ThrowOnUnsupportedDecoratorContext(context);
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/decorators/Guya.ts
+++ b/web/src/engine/websites/decorators/Guya.ts
@@ -49,7 +49,7 @@ export function MangaAJAX(pattern: RegExp) {
     return function DecorateClass<T extends Common.Constructor>(ctor: T, context?: ClassDecoratorContext): T {
         Common.ThrowOnUnsupportedDecoratorContext(context);
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/decorators/MangaNel.ts
+++ b/web/src/engine/websites/decorators/MangaNel.ts
@@ -55,7 +55,7 @@ export function MangaCSS(pattern: RegExp, query: string = queryMangaTitle) {
     return function DecorateClass<T extends Common.Constructor>(ctor: T, context?: ClassDecoratorContext): T {
         Common.ThrowOnUnsupportedDecoratorContext(context);
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/decorators/PizzaReader.ts
+++ b/web/src/engine/websites/decorators/PizzaReader.ts
@@ -56,7 +56,7 @@ export function MangaAJAX(pattern: RegExp) {
         Common.ThrowOnUnsupportedDecoratorContext(context);
 
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/decorators/ReaderFront.ts
+++ b/web/src/engine/websites/decorators/ReaderFront.ts
@@ -124,7 +124,7 @@ export function MangaAJAX(pattern: RegExp, apiUrl: string) {
     return function DecorateClass<T extends Common.Constructor>(ctor: T, context?: ClassDecoratorContext): T {
         Common.ThrowOnUnsupportedDecoratorContext(context);
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/decorators/WordPressMadara.ts
+++ b/web/src/engine/websites/decorators/WordPressMadara.ts
@@ -83,7 +83,7 @@ export function MangaCSS(pattern: RegExp, query: string = queryMangaTitle) {
     return function DecorateClass<T extends Common.Constructor>(ctor: T, context?: ClassDecoratorContext): T {
         Common.ThrowOnUnsupportedDecoratorContext(context);
         return class extends ctor {
-            public ValidateMangaURL(this: MangaScraper, url: string): boolean {
+            public async ValidateMangaURL(url: string): Promise<boolean> {
                 const source = pattern.source.replaceAll('{origin}', this.URI.origin).replaceAll('{hostname}', this.URI.hostname);
                 return new RegExpSafe(source, pattern.flags).test(url);
             }

--- a/web/src/engine/websites/templates/DelitoonBase.ts
+++ b/web/src/engine/websites/templates/DelitoonBase.ts
@@ -51,7 +51,7 @@ export class DelitoonBase extends DecoratableMangaScraper {
     protected readonly apiUrl = new URL('/api/balcony-api-v2/', this.URI);
     protected BalconyID: string = 'DELITOON_COM';
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return new RegExpSafe(`^${this.URI.origin}/detail/[^/]+$`).test(url);
     }
 

--- a/web/src/engine/websites/templates/LineWebtoonBase.ts
+++ b/web/src/engine/websites/templates/LineWebtoonBase.ts
@@ -140,7 +140,7 @@ export class LineWebtoonBase extends DecoratableMangaScraper {
     protected pageScript = defaultPageScript;
     private readonly interactionTaskPool = new TaskPool(1, RateLimit.PerMinute(30));
 
-    public override ValidateMangaURL(url: string): boolean {
+    public override async ValidateMangaURL(url: string): Promise<boolean> {
         return this.mangaRegexp.test(url) && url.startsWith(this.URI.origin);
     }
 


### PR DESCRIPTION
Suppose website change domain often we have 2 possibilities for clipboard to work: 

1) Its following a pattern : we can use an adapted regexp i.e      
`   /https?:\/\/w+\d*.mangafreak.me\/Manga\/[^/]+$/.test(url);`

2) its NOT following a pattern ie "josephbent.com, galaxymanga.net" .

This PR allows performing async actions in `ValidateMangaUrl `, making dynamic domain update possible for clipboard use.

Please see MangaGalaxy.ts for the how to. The rest is just updating mangaplugins and connectors

