### PR TITLE
Allow Uint8Array as GetTypedData parameters

### DIFF
--- a/web/src/engine/websites/decorators/Common.ts
+++ b/web/src/engine/websites/decorators/Common.ts
@@ -559,8 +559,8 @@ export function ImageAjaxFromHTML(queryImage: string, detectMimeType = false, de
 /**
  * A helper function to detect and get the mime typed image data of a buffer.
  */
-export async function GetTypedData(buffer: ArrayBuffer): Promise<Blob> {
-    const bytes = new Uint8Array(buffer);
+export async function GetTypedData(buffer: ArrayBuffer | Uint8Array): Promise<Blob> {
+    const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
     // WEBP [52 49 46 46 . . . . 57 45 42 50]
     if (bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) {
         return new Blob([bytes], { type: 'image/webp' });


### PR DESCRIPTION
* npm run checks now gives errors because `Common.GetTypedData` wants STRICT `ArrayBuffer` as parameter.

* This appends when 

1. We get picture as `ArrayBuffer`,  create an `Uint8Array` from it, decrypt the picture using that `Uint8Array`.
2. We `return Common.GetTypedData(decrypted_Uint8Array)`

I.e : NicoNicoSeiga.

Its stupid to convert `decrypted_Uint8Array` to an ArrayBuffer AGAIN because `GetTypedData` will convert it to `Uint8Array` anyway.

 