### PR TITLE
Blacklist facebook comments plugin

### DIFF
--- a/web/src/engine/platform/BloatGuard.ts
+++ b/web/src/engine/platform/BloatGuard.ts
@@ -57,4 +57,6 @@ const patterns = [
     '*://pickupfaxmultitude.com/*',
     '*://t7cp4fldl.com/*',
     '*://tumultmarten.com/*',
+    '*://*.facebook.com/*',
+    '*://*.facebook.net/*',
 ];

--- a/web/src/engine/platform/BloatGuard.ts
+++ b/web/src/engine/platform/BloatGuard.ts
@@ -57,6 +57,6 @@ const patterns = [
     '*://pickupfaxmultitude.com/*',
     '*://t7cp4fldl.com/*',
     '*://tumultmarten.com/*',
-    '*://*.facebook.com/*',
-    '*://*.facebook.net/*',
+    '*://www.facebook.com/*/plugins/comments.php*',
+    '*://www.facebook.net/*/plugins/comments.php*',
 ];


### PR DESCRIPTION
Solves issue with mangahere having random long timeouts

> (node:20188) electron: Failed to load URL: https://www.facebook.com/v2.10/plugins/comments.php?app_id=250769461611065&channel=https%3A%2F%2Fstaticxx.facebook.com%2Fx%2Fconnect%2Fxd_arbiter%2F%3Fversion%3D46%23cb%3Dfaa6c354a43a87de7%26domain%3Dwww.mangahere.cc%26is_canvas%3Dfalse%26origin%3Dhttps%253A%252F%252Fwww.mangahere.cc%252Ffc0a582566ff38cf5%26relation%3Dparent.parent&container_width=0&height=100&href=http%3A%2F%2Fwww.mangahere.co%2Fmanga%2Fvigilante_boku_no_hero_academia_illegals%2Fc123%2F1.html&locale=en_US&sdk=joey&version=v2.10&width=702 with error: ERR_BLOCKED_BY_RESPONSE