### PR TITLE
disable Chrome background throttling

### DIFF
--- a/app/nw/scripts/build-app.mjs
+++ b/app/nw/scripts/build-app.mjs
@@ -26,7 +26,7 @@ const manifest = {
         'https://app.hakuneko.download/*',
         `${new URL(pkgConfig.url).origin}/*`,
     ],
-    'chromium-args': '--disable-raf-throttling',
+    'chromium-args': '--disable-background-timer-throttling',
     'user-agent': targetConfig['user-agent'] ?? null,
     dependencies: pkgConfig.dependencies
 };

--- a/app/nw/scripts/build-app.mjs
+++ b/app/nw/scripts/build-app.mjs
@@ -26,7 +26,7 @@ const manifest = {
         'https://app.hakuneko.download/*',
         `${new URL(pkgConfig.url).origin}/*`,
     ],
-    'chromium-args': null,
+    'chromium-args': '--disable-raf-throttling',
     'user-agent': targetConfig['user-agent'] ?? null,
     dependencies: pkgConfig.dependencies
 };

--- a/web/src/engine/platform/electron/RemoteBrowserWindow.ts
+++ b/web/src/engine/platform/electron/RemoteBrowserWindow.ts
@@ -55,6 +55,7 @@ export default class RemoteBrowserWindow implements IRemoteBrowserWindow {
             webPreferences: {
                 sandbox: true,
                 webSecurity: true,
+                backgroundThrottling: false,
                 contextIsolation: false, // Disabled for sharing `window` instance in pre-load script: https://www.electronjs.org/docs/latest/tutorial/context-isolation#what-is-it
                 nodeIntegration: false,
                 nodeIntegrationInWorker: false,


### PR DESCRIPTION
Users has been complaining that "downloads are slower in background".

This is using electron window parameter & nwjs command line switch.

The impact needs to be determined.