### PR TITLE
Fix Reaperscans inconsistent downloads.

### DIFF
--- a/web/src/engine/websites/ReaperScans.ts
+++ b/web/src/engine/websites/ReaperScans.ts
@@ -81,7 +81,7 @@ export default class extends DecoratableMangaScraper {
     }
 
     public override async FetchPages(chapter: Chapter): Promise<Page[]> {
-        const pages = await Common.FetchPagesSinglePageCSS.call(this, chapter, 'div#content div.container > div img:not([alt *= "thumb"])', PageLinkExtractor);
+        let pages = await Common.FetchPagesSinglePageCSS.call(this, chapter, 'div#content div.container > div img:not([alt *= "thumb"]), div#S\\:1 div.container > div img:not([alt *= "thumb"])', PageLinkExtractor);
         return pages.filter(page => !page.Link.href.match(/\._000_slr\.jpg$/));//incorrect image in Solo Leveling Ragnarok chapter 1
     }
 }

--- a/web/src/engine/websites/ReaperScans.ts
+++ b/web/src/engine/websites/ReaperScans.ts
@@ -81,7 +81,7 @@ export default class extends DecoratableMangaScraper {
     }
 
     public override async FetchPages(chapter: Chapter): Promise<Page[]> {
-        let pages = await Common.FetchPagesSinglePageCSS.call(this, chapter, 'div#content div.container > div img:not([alt *= "thumb"]), div#S\\:1 div.container > div img:not([alt *= "thumb"])', PageLinkExtractor);
+        const pages = await Common.FetchPagesSinglePageCSS.call(this, chapter, 'div#content div.container > div img:not([alt *= "thumb"]), div#S\\:1 div.container > div img:not([alt *= "thumb"])', PageLinkExtractor);
         return pages.filter(page => !page.Link.href.match(/\._000_slr\.jpg$/));//incorrect image in Solo Leveling Ragnarok chapter 1
     }
 }


### PR DESCRIPTION
I've found that the reaperscans plugin returns no images for every 5 or so chapters (at least on my end). The reason seems to be that in some cases the server sends a html template string inside the div#content and actually stores the container content inside a #S:1 div instead. Adding that css selector as a possibility returns the plugin to 100% retrieval again.