### PR TITLE
Improve ComicK api params

### DIFF
--- a/web/src/engine/websites/ComicK.ts
+++ b/web/src/engine/websites/ComicK.ts
@@ -91,7 +91,7 @@ export default class extends DecoratableMangaScraper {
 
     private async GetMangasFromPage(page: number, provider: MangaPlugin): Promise<Manga[]> {
         try {
-            const data = await FetchJSON<APIManga[]>(new Request(new URL(`v1.0/search?page=${page}&limit=49`, this.apiUrl)));
+            const data = await FetchJSON<APIManga[]>(new Request(new URL(`v1.0/search?page=${page}&limit=50&sort=user_follow_count`, this.apiUrl)));
             return data.map(item => new Manga(this, provider, item.hid, item.title.trim()));
         } catch { // TODO: Do not return empty list for generic errors
             return [];


### PR DESCRIPTION
I noticed that comick only allows the page and limit to be <=50. but since comick hosts way more than 2500 (50*50) comics on it's site, the fetcher misses a ton of the popular ones. i noticed this because i was trying to download the no 1 most popular manhwa on the site which wasn't found in haruneko. Sorting the api by user_follow_count, shows only the 2500 most popular comics on the site. still not perfect but certainly better then the ones uploaded latest. oh and the limit could be 50 instead of 49 adding another 50 total results.