### PR TITLE
Mangahere add protocol to urls

### DIFF
--- a/web/src/engine/websites/MangaHere_e2e.ts
+++ b/web/src/engine/websites/MangaHere_e2e.ts
@@ -1,6 +1,7 @@
 import { TestFixture } from '../../../test/WebsitesFixture';
 
-const config = {
+//Case using fetchScriptedImages
+new TestFixture({
     plugin: {
         id: 'mangahere',
         title: 'MangaHere'
@@ -19,6 +20,26 @@ const config = {
         size: 186_010,
         type: 'image/jpeg'
     }
-};
+}).AssertWebsite();
 
-new TestFixture(config).AssertWebsite();
+//Case with newImgs + missing protocol in images urls
+new TestFixture({
+    plugin: {
+        id: 'mangahere',
+        title: 'MangaHere'
+    },
+    container: {
+        url: 'https://www.mangahere.cc/manga/the_lazy_prince_becomes_a_genius/',
+        id: '/manga/the_lazy_prince_becomes_a_genius/',
+        title: 'The Lazy Prince Becomes a Genius'
+    },
+    child: {
+        id: '/manga/the_lazy_prince_becomes_a_genius/c001/1.html',
+        title: 'Ch.001'
+    },
+    entry: {
+        index: 0,
+        size: 194_388,
+        type: 'image/jpeg'
+    }
+}).AssertWebsite();

--- a/web/src/engine/websites/decorators/DM5.ts
+++ b/web/src/engine/websites/decorators/DM5.ts
@@ -55,7 +55,7 @@ export async function FetchPagesSinglePageScript(this: MangaScraper, chapter: Ch
                 });
             }
             try {
-                const images = window.newImgs ? window.newImgs : await fetchScriptedImages();
+                const images = window.newImgs ? window.newImgs.map(image => new URL(image, window.location.href).href) : await fetchScriptedImages();
                 const lastImage = new Image();
                 lastImage.onload = () => {
                     if(lastImage.naturalWidth === 1000 && lastImage.naturalHeight === 563) {
@@ -72,10 +72,7 @@ export async function FetchPagesSinglePageScript(this: MangaScraper, chapter: Ch
     `;
     const uri = new URL(chapter.Identifier, this.URI);
     const images = await FetchWindowScript<string[]>(new Request(uri), script, 1000);
-    return images.map(url => {
-        if(!url.includes(uri.protocol)) url = uri.protocol+url;
-        return new Page(this, chapter, new URL(url), { Referer: uri.href });
-    });
+    return images.map(url => new Page(this, chapter, new URL(url), { Referer: uri.href }));
 }
 
 /**

--- a/web/src/engine/websites/decorators/DM5.ts
+++ b/web/src/engine/websites/decorators/DM5.ts
@@ -72,7 +72,10 @@ export async function FetchPagesSinglePageScript(this: MangaScraper, chapter: Ch
     `;
     const uri = new URL(chapter.Identifier, this.URI);
     const images = await FetchWindowScript<string[]>(new Request(uri), script, 1000);
-    return images.map(url => new Page(this, chapter, new URL(url), { Referer: uri.href }));
+    return images.map(url => { 
+        if(!url.includes(uri.protocol)) url = uri.protocol+url;
+        return new Page(this, chapter, new URL(url), { Referer: uri.href });
+    });
 }
 
 /**

--- a/web/src/engine/websites/decorators/DM5.ts
+++ b/web/src/engine/websites/decorators/DM5.ts
@@ -72,7 +72,7 @@ export async function FetchPagesSinglePageScript(this: MangaScraper, chapter: Ch
     `;
     const uri = new URL(chapter.Identifier, this.URI);
     const images = await FetchWindowScript<string[]>(new Request(uri), script, 1000);
-    return images.map(url => { 
+    return images.map(url => {
         if(!url.includes(uri.protocol)) url = uri.protocol+url;
         return new Page(this, chapter, new URL(url), { Referer: uri.href });
     });


### PR DESCRIPTION
fixes #966

The mangahere chapters url are returned without https: (meaning it's //example.org/whatever) and therefore considered as invalid url. This prepends the url procotol if missing.
Only "if missing" because mangafox urls are corrects and the DM5 code is shared.