### PR TITLE
ShonenMagazine: Fix the dimensions of the pieces

### DIFF
--- a/web/src/engine/websites/CiaoPlus.ts
+++ b/web/src/engine/websites/CiaoPlus.ts
@@ -49,6 +49,7 @@ export default class extends DecoratableMangaScraper {
     protected apiUrl = 'https://api.ciao.shogakukan.co.jp/';
     protected requestHashProperty = 'x-bambi-hash';
     protected requestHashAppend : string = '';
+    protected pieceScale = 8;
 
     public constructor(id = 'ciaoplus', label = 'Ciao Plus', url = 'https://ciao.shogakukan.co.jp', tags = [Tags.Media.Manga, Tags.Language.Japanese, Tags.Source.Aggregator]) {
         super(id, label, url, ...tags );
@@ -102,13 +103,14 @@ export default class extends DecoratableMangaScraper {
     public override async FetchImage(page: Page<PageSeed>, priority: Priority, signal: AbortSignal): Promise<Blob> {
         const blob = await Common.FetchImageAjax.call(this, page, priority, signal);
         const COL_NUM = 4;
+        const PIECE_SCALE = this.pieceScale;
 
         return DeScramble(blob, async (image, ctx) => {
 
             function getPieceDimension(width: number, height: number, t: number): TDimension {
 
                 if (width < t || height < t) return null;
-                const s = Cs(t, 8);
+                const s = Cs(t, PIECE_SCALE);
                 return width > s && height > s && (width = Math.floor(width / s) * s, height = Math.floor(height / s) * s),
                 {
                     width: Math.floor(width / t),

--- a/web/src/engine/websites/ShonenMagazine.ts
+++ b/web/src/engine/websites/ShonenMagazine.ts
@@ -17,6 +17,7 @@ export default class extends CiaoPlus {
         super('shonenmagazine', `週刊少年マガジ (Weekly Shonen Magazine & Pocket Magazine)`, 'https://pocket.shonenmagazine.com', [Tags.Language.Japanese, Tags.Source.Official, Tags.Media.Manga]);
         this.apiUrl = 'https://api.pocket.shonenmagazine.com/';
         this.requestHashProperty = 'x-manga-hash';
+        this.pieceScale = 32;
     }
 
     public override get Icon() {

--- a/web/src/engine/websites/ShonenMagazine_e2e.ts
+++ b/web/src/engine/websites/ShonenMagazine_e2e.ts
@@ -20,3 +20,24 @@ new TestFixture({
         type: 'image/png'
     }
 }).AssertWebsite();
+
+new TestFixture({
+    plugin: {
+        id: 'shonenmagazine',
+        title: '週刊少年マガジ (Weekly Shonen Magazine & Pocket Magazine)'
+    },
+    container: {
+        url: 'https://pocket.shonenmagazine.com/title/00553/episode/209248',
+        id: '553',
+        title: '頭文字D'
+    },
+    child: {
+        id: '209248',
+        title: '【Vol.1】ハチロク買おーぜ'
+    },
+    entry: {
+        index: 0,
+        size: 760_906,
+        type: 'image/png'
+    }
+}).AssertWebsite();


### PR DESCRIPTION
Depending on the dimensions of the image, it may not be correctly unscrambled.
This issue can occur if either the width or height of the image is not an integer multiple of 32.

In that case, the dimensions of each piece into which the image is divided will be incorrect.
It seems that the range into which the image is divided must be a multiple of 32.
This method of division has not changed since the website was redesigned.
https://github.com/manga-download/hakuneko/blob/3b87885a8af64d26f9b2fa79c2ad8754b3ecf764/src/web/mjs/connectors/templates/CoreView.mjs#L130-L133

### To Reproduce

1. Name of connector: `週刊少年マガジ (Weekly Shonen Magazine & Pocket Magazine)`
2. Name of manga: `頭文字D`
3. Name of chapter: `【Vol.1】ハチロク買おーぜ`
   - URL of chapter: https://pocket.shonenmagazine.com/title/00553/episode/209248
4. Compare the downloaded image with the one displayed on the website.

#### Expected behavior

The downloaded image matches the one displayed on the website.
Also, the width of the piece is 168 px.

#### Actual behavior

The downloaded image does not match the one displayed on the website.
Also, the width of the piece is **170** px.