### PR TITLE
Fix MangaCrab not working

### DIFF
--- a/web/src/engine/websites/MangaCrab.ts
+++ b/web/src/engine/websites/MangaCrab.ts
@@ -12,10 +12,8 @@ const chapterScript = `
 
 const pageScript = `
     [...document.querySelectorAll('div.page-break img.wp-manga-chapter-img[id^="image-"]')]
-    .flatMap(img => {
-        const k = img.getAttributeNames().find(n => n.startsWith('zdk2-'));
-        return k ? [img.getAttribute(k)] : [];
-    });
+        .map(img => [...img.attributes].find(attribute => attribute.value.startsWith('/validate2.php'))?.value)
+        .filter(img => img);
 `;
 
 @Common.MangaCSS(/^{origin}\/series\/[^/]+\/$/, 'h1.post-title')


### PR DESCRIPTION
 `PagesSinglePageCSS` has now been replaced by `PagesSinglePageJS`.
 I'm not sure if a timeout of 0 seconds is appropriate.
 The `data-img-*` attribute has been changed to `wp-manga-chapter-img`, and the URL is now retrieved using the `zdk2-*` attribute.
