### PR TITLE
Desu : fix VS typo

### DIFF
--- a/web/src/engine/websites/Desu.ts
+++ b/web/src/engine/websites/Desu.ts
@@ -20,4 +20,3 @@ export default class extends DecoratableMangaScraper {
         return icon;
     }
 }
-


### PR DESCRIPTION
I make fixes based on the developer console. Therefore, I don't know if there are any other bugs in this connector. Because I can't get around the first problem.
In HakuNeko, the connectors are located in the “/cache/mjs/connectors” folder. In HaruNeko, are the connectors packed, or can they also be found somewhere?