### PR TITLE
fix : ComiciViewer: new api

### DIFF
--- a/web/src/engine/websites/ComicRide.ts
+++ b/web/src/engine/websites/ComicRide.ts
@@ -1,11 +1,16 @@
 import { Tags } from '../Tags';
 import icon from './ComicRide.webp';
-import { ComiciViewer } from'./templates/ComiciViewer';
+import { ComiciViewer } from './templates/ComiciViewer';
+import * as Common from './decorators/Common';
 
+@Common.MangaCSS(/^{origin}\/series\/[^/]+\/?$/, 'h1.series-h-title', Common.WebsiteInfoExtractor({ queryBloat: 'span' }))
+@Common.MangasMultiPageCSS<HTMLAnchorElement>('a.series-list-item-link', Common.PatternLinkGenerator('/series/list/up/{page}', 1), 0, anchor => ({ id: anchor.pathname, title: anchor.querySelector('div.series-list-item-h span').textContent.trim() }))
 export default class extends ComiciViewer {
 
     public constructor() {
         super('comicride', `Comic Ride`, 'https://comicride.jp', Tags.Media.Manga, Tags.Language.Japanese, Tags.Source.Official);
+        this.apiUrl = new URL('https://comicride.jp/api/');
+        this.useNewAPI = true;
     }
 
     public override get Icon() {

--- a/web/src/engine/websites/ComicRide_e2e.ts
+++ b/web/src/engine/websites/ComicRide_e2e.ts
@@ -11,7 +11,7 @@ new TestFixture({
         title: '呪われ侯爵様の訳ありメイド',
     },
     child: {
-        id: '/episodes/c0ee21c1e9472/',
+        id: '/episodes/c0ee21c1e9472',
         title: '第1話',
     },
     entry: {

--- a/web/src/engine/websites/JEnta.ts
+++ b/web/src/engine/websites/JEnta.ts
@@ -1,11 +1,16 @@
 import { Tags } from '../Tags';
 import icon from './JEnta.webp';
-import { ComiciViewer } from'./templates/ComiciViewer';
+import { ComiciViewer } from './templates/ComiciViewer';
+import * as Common from './decorators/Common';
 
+@Common.MangaCSS(/^{origin}\/series\/[^/]+\/?$/, 'h1.series-h-title', Common.WebsiteInfoExtractor({ queryBloat: 'span' }))
+@Common.MangasMultiPageCSS<HTMLAnchorElement>('a.series-list-item-link', Common.PatternLinkGenerator('/series/list/up/{page}', 1), 0, anchor => ({ id: anchor.pathname, title: anchor.querySelector('div.series-list-item-h span').textContent.trim() }))
 export default class extends ComiciViewer {
 
     public constructor() {
         super('jenta', 'J-Enta', 'https://comic.j-nbooks.jp/', Tags.Media.Manga, Tags.Language.Japanese, Tags.Source.Official);
+        this.apiUrl = new URL('https://comic.j-nbooks.jp/api/');
+        this.useNewAPI = true;
     }
 
     public override get Icon() {

--- a/web/src/engine/websites/JEnta_e2e.ts
+++ b/web/src/engine/websites/JEnta_e2e.ts
@@ -11,7 +11,7 @@ new TestFixture({
         title: '異世界でテイムした最強の使い魔は、幼馴染の美少女でした'
     },
     child: {
-        id: '/episodes/b5d46d0267d8a/',
+        id: '/episodes/b5d46d0267d8a',
         title: '第1話①'
     },
     entry: {

--- a/web/src/engine/websites/RimacomiPlus_e2e.ts
+++ b/web/src/engine/websites/RimacomiPlus_e2e.ts
@@ -11,7 +11,7 @@ new TestFixture({
         title: '包帯ごっこ',
     },
     child: {
-        id: '/cocohana/episodes/7cba174d95a20/',
+        id: '/cocohana/episodes/5e926ec620784/',
         title: '第1話',
     },
     entry: {

--- a/web/src/engine/websites/TakeComic.ts
+++ b/web/src/engine/websites/TakeComic.ts
@@ -3,34 +3,17 @@ import icon from './TakeComic.webp';
 import { ComiciViewer } from './templates/ComiciViewer';
 import * as Common from './decorators/Common';
 
-import { FetchJSON } from '../platform/FetchProvider';
-import { type Manga, Chapter } from '../providers/MangaPlugin';
-
-type APIChapters = {
-    series: {
-        episodes: {
-            id: string;
-            title: string;
-        }[]
-    }
-};
-
 @Common.MangaCSS(/^{origin}\/series\/[^/]+\/?$/, 'h1.series-h-title', Common.WebsiteInfoExtractor({ queryBloat: 'span' }))
 @Common.MangasMultiPageCSS<HTMLAnchorElement>('a.series-list-item-link', Common.PatternLinkGenerator('/series/list/up/{page}', 1), 0, anchor => ({ id: anchor.pathname, title: anchor.querySelector('div.series-list-item-h span').textContent.trim() }))
-
 export default class extends ComiciViewer {
 
     public constructor() {
         super('takecomic', `TakeComic`, 'https://takecomic.jp', Tags.Media.Manga, Tags.Language.Japanese, Tags.Source.Official);
         this.apiUrl = new URL('https://takecomic.jp/api/');
+        this.useNewAPI = true;
     }
 
     public override get Icon() {
         return icon;
-    }
-
-    public override async FetchChapters(manga: Manga): Promise<Chapter[]> {
-        const { series: { episodes } } = await FetchJSON<APIChapters>(new Request(new URL(`./episodes?seriesHash=${manga.Identifier.split('/').at(-1)}&episodeFrom=1&episodeTo=9999`, this.apiUrl)));
-        return episodes.map(({id, title })=> new Chapter(this, manga, `/episodes/${id}`, title) );
     }
 }

--- a/web/src/engine/websites/YoungAnimal_e2e.ts
+++ b/web/src/engine/websites/YoungAnimal_e2e.ts
@@ -11,7 +11,7 @@ new TestFixture({
         title: '拷問バイトくんの日常'
     },
     child: {
-        id: '/episodes/36b790450439c/',
+        id: '/episodes/1ee1238190925/',
         title: '第1話'
     },
     entry: {

--- a/web/src/engine/websites/templates/ComiciViewer.ts
+++ b/web/src/engine/websites/templates/ComiciViewer.ts
@@ -1,5 +1,5 @@
 import { FetchCSS, FetchJSON } from '../../platform/FetchProvider';
-import { DecoratableMangaScraper, type Manga, type Chapter, Page } from '../../providers/MangaPlugin';
+import { DecoratableMangaScraper, type Manga, Chapter, Page } from '../../providers/MangaPlugin';
 import type { Priority } from '../../taskpool/DeferredTask';
 import DeScramble from '../../transformers/ImageDescrambler';
 import * as Common from '../decorators/Common';
@@ -16,34 +16,28 @@ type ScrambleData = {
     scramble: string;
 };
 
+type APIChapters = {
+    series: {
+        episodes: {
+            id: string;
+            title: string;
+        }[]
+    }
+};
+
 function StripTrailingSlash(pathname: string): string {
     return pathname.replace(/\/$/, '');
 }
 
-function MangaInfoExtractor(div: HTMLDivElement) {
-    return {
-        id: StripTrailingSlash(div.querySelector('a').pathname),
-        title: div.querySelector<HTMLHeadingElement>('h2.title-text').innerText.trim(),
-    };
-}
-
-function ChapterInfoExtractor(element: HTMLElement) {
-    return {
-        id: new URL(element.dataset.href).pathname,
-        title: element.querySelector<HTMLSpanElement>('span.series-ep-list-item-h-text').innerText.trim()/*.replace(manga.Title, '').trim() || manga.Title*/,
-    };
-}
-
-function ChapterLinkResolver(manga: Manga): URL {
-    return new URL(`${manga.Identifier}/list`, this.URI);
-}
-
 @Common.MangaCSS(/^{origin}\/series\/[^/]+\/?$/, 'h1.series-h-title span:not([class])', (span, uri) => ({ id: StripTrailingSlash(uri.pathname), title: span.innerText.trim() }))
-@Common.MangasMultiPageCSS('div.series-box-vertical', Common.PatternLinkGenerator('/series/list?page={page}', 0), 0, MangaInfoExtractor)
-@Common.ChaptersSinglePageCSS('div.series-ep-list a[data-href]', ChapterLinkResolver, ChapterInfoExtractor)
+@Common.MangasMultiPageCSS('div.series-box-vertical', Common.PatternLinkGenerator('/series/list?page={page}', 0), 0, element => ({
+    id: StripTrailingSlash(element.querySelector('a').pathname),
+    title: element.querySelector<HTMLHeadingElement>('h2.title-text').innerText.trim()
+}))
 export class ComiciViewer extends DecoratableMangaScraper {
 
     protected apiUrl = this.URI;
+    protected useNewAPI = false;
     private readonly identityTileMap = new Array(16).fill(null).map((_, index) => ({ col: index / 4 >> 0, row: index % 4 >> 0 }));
 
     public override async FetchPages(chapter: Chapter): Promise<Page<ScrambleData>[]> {
@@ -51,12 +45,12 @@ export class ComiciViewer extends DecoratableMangaScraper {
         const viewerId = viewer.getAttribute('comici-viewer-id') ?? viewer.dataset.comiciViewerId;
         const { totalPages } = await this.FetchContentInfo(chapter, viewerId, viewer.dataset.memberJwt, 1);
         const { result } = await this.FetchContentInfo(chapter, viewerId, viewer.dataset.memberJwt, totalPages);
-        return result.map(image => new Page<ScrambleData>(this, chapter, new URL(image.imageUrl), { scramble: image.scramble, Referer: this.URI.href }));
+        return result.map(({ imageUrl, scramble }) => new Page<ScrambleData>(this, chapter, new URL(imageUrl), { scramble, Referer: this.URI.href }));
     }
 
     public override async FetchImage(page: Page<ScrambleData>, priority: Priority, signal: AbortSignal): Promise<Blob> {
-        const data = await Common.FetchImageAjax.call(this, page, priority, signal);
-        return !page.Parameters?.scramble ? data : DeScramble(data, async (image, ctx) => {
+        const blob = await Common.FetchImageAjax.call(this, page, priority, signal);
+        return !page.Parameters?.scramble ? blob : DeScramble(blob, async (image, ctx) => {
             const scrambleTileMap = page.Parameters.scramble.replace(/\s+/g, '').slice(1).slice(0, -1).split(',').map(index => this.identityTileMap[index]);
             const tileWidth = Math.floor(image.width / 4);
             const tileHeight = Math.floor(image.height / 4);
@@ -71,18 +65,22 @@ export class ComiciViewer extends DecoratableMangaScraper {
     }
 
     private FetchContentInfo(chapter: Chapter, viewerId: string, userId: string, pageTo: number): Promise<APIPages> {
-        const uri = new URL('./book/contentsInfo', this.apiUrl);
-        uri.search = new URLSearchParams({
-            'comici-viewer-id': viewerId,
-            'user-id': userId,
-            'page-from': '0',
-            'page-to': `${pageTo}`,
-        }).toString();
-        const request = new Request(uri, {
+        return FetchJSON<APIPages>(new Request(new URL(`./book/contentsInfo?comici-viewer-id=${viewerId}&user-id=${userId}&page-from=0&page-to=${pageTo}`, this.apiUrl), {
             headers: {
                 Referer: new URL(chapter.Identifier, this.URI).href,
             },
-        });
-        return FetchJSON<APIPages>(request);
+        }));
+    }
+
+    public override async FetchChapters(manga: Manga): Promise<Chapter[]> {
+        if (!this.useNewAPI)
+            return Common.FetchChaptersSinglePageCSS.call(this, manga, 'div.series-ep-list a[data-href]', manga => new URL(`${manga.Identifier}/list`, this.URI), element => ({
+                id: new URL(element.dataset.href).pathname,
+                title: element.querySelector<HTMLSpanElement>('span.series-ep-list-item-h-text').innerText.trim()
+            }));
+        else {
+            const { series: { episodes } } = await FetchJSON<APIChapters>(new Request(new URL(`./episodes?seriesHash=${manga.Identifier.split('/').at(-1)}&episodeFrom=1&episodeTo=9999`, this.apiUrl)));
+            return episodes.map(({ id, title }) => new Chapter(this, manga, `/episodes/${id}`, title))/*.replace(manga.Title, '').trim() || manga.Title*/;
+        }
     }
 }


### PR DESCRIPTION
Basically : more websites are using new Comici version and CSS, so template is modified after TakeComic.
In those, chapters are fetched using the API .

Reference : https://github.com/manga-download/hakuneko/issues/8367