### PR TITLE
Added 7z Exporter

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "exifr": "7.1.3",
         "jszip": "3.10.1",
+        "7z-wasm": "1.2.0",
         "pdfkit": "github:manga-download/pdfkit#v0.17.2",
         "protobufjs": "8.0.0"
     },

--- a/web/src/engine/SettingsGlobal.ts
+++ b/web/src/engine/SettingsGlobal.ts
@@ -65,6 +65,7 @@ export async function Initialize(settingsManager: SettingsManager, frontends: IF
             MangaExportFormat.RAWs,
             { key: MangaExportFormat.RAWs, label: R.Settings_Global_MangaExportFormat_FolderWithImages },
             { key: MangaExportFormat.CBZ, label: R.Settings_Global_MangaExportFormat_ComicBookArchive },
+            { key: MangaExportFormat.C7Z, label: R.Settings_Global_MangaExportFormat_SevenZipArchive },
             { key: MangaExportFormat.EPUB, label: R.Settings_Global_MangaExportFormat_ElectronicPublication },
             { key: MangaExportFormat.PDF, label: R.Settings_Global_MangaExportFormat_PortableDocumentFormat },
         ),

--- a/web/src/engine/exporters/MangaExporterRegistry.ts
+++ b/web/src/engine/exporters/MangaExporterRegistry.ts
@@ -2,6 +2,7 @@ import type { StorageController } from '../StorageController';
 import type { MangaExporter } from './MangaExporter';
 import { ImageDirectoryExporter } from './ImageDirectoryExporter';
 import { ComicBookArchiveExporter } from './ComicBookArchiveExporter';
+import { SevenZipArchiveExporter } from './SevenZipArchiveExporter';
 import { ElectronicPublicationExporter } from './ElectronicPublicationExporter';
 import { PortableDocumentFormatExporter } from './PortableDocumentFormatExporter';
 
@@ -29,6 +30,10 @@ export enum MangaExportFormat {
     /**
      * Save images from website in a EPUB file
      */
+    C7Z = 'application/x-7z-compressed',
+    /**
+     * Save images from website in a EPUB file
+     */
     EPUB = 'application/epub+zip',
     /**
      * Save images from website in a document, non-compliant images will be converted to JPEG with q=95%
@@ -40,6 +45,7 @@ export function CreateChapterExportRegistry(storageController: StorageController
     return {
         [MangaExportFormat.RAWs]: new ImageDirectoryExporter(storageController),
         [MangaExportFormat.CBZ]: new ComicBookArchiveExporter(storageController),
+        [MangaExportFormat.C7Z]: new SevenZipArchiveExporter(storageController),
         [MangaExportFormat.PDF]: new PortableDocumentFormatExporter(storageController),
         [MangaExportFormat.EPUB]: new ElectronicPublicationExporter(storageController),
     };

--- a/web/src/engine/exporters/SevenZipArchiveExporter.ts
+++ b/web/src/engine/exporters/SevenZipArchiveExporter.ts
@@ -1,0 +1,73 @@
+import { MangaExporter } from './MangaExporter';
+import { SanitizeFileName } from '../StorageController';
+import { TaskPool, Priority } from '../taskpool/TaskPool';
+
+import SevenZip from '7z-wasm';
+import SevenZipURL from '7z-wasm/7zz.wasm?url'; // <-- Vite asset URL. Otherwise wasm is served as Mimetype text/html and fails
+
+
+export class SevenZipArchiveExporter extends MangaExporter {
+
+    public override async Export(sourceFileList: Map<number, string>, targetDirectory: FileSystemDirectoryHandle, chapterTitle: string, _mangaTitle?: string): Promise<void> {
+        // Copied ImageDirectoryExporter to get images but stripped out all file writes
+        const taskPool = new TaskPool(8);
+        const digits = sourceFileList.size.toString().length;
+        const folderName = SanitizeFileName(chapterTitle);
+        const archiveName = `${folderName}.7z`;
+        const promises = [...sourceFileList].map(([ index, tempfile ]) => taskPool.Add(
+            () => super.ReadTempImageData(tempfile, index, digits)
+            , Priority.Normal));
+        const images = await Promise.all(promises);
+
+        
+
+        // Initialize 7z-wasm (locateFile is needed for proper loading)
+        const sevenZip = await SevenZip({
+            locateFile: (file: string) => {
+                if (file.endsWith('.wasm')) return SevenZipURL;
+                return file;
+            }
+        });
+
+        // Prep virtual emspripten Input/Output directories
+        sevenZip.FS.mkdir(`/${folderName}`);
+
+        // Copy images to virtual FS
+        for (const { name, data } of images) {
+            const buffer = new Uint8Array(await data.arrayBuffer());
+            const stream = sevenZip.FS.open(`/${folderName}/${name}`, 'w+');
+            sevenZip.FS.write(stream, buffer, 0, buffer.length);
+            sevenZip.FS.close(stream);
+        }
+
+        // Run 7z (Max compression mode without stacking algorithms)
+        await sevenZip.callMain([
+            'a',
+            '-t7z',
+            '-mx=9',
+            '-myx=9',
+            `/${archiveName}`,
+            `/${folderName}`
+        ]);
+
+        // Read 7z archive from virtual FS
+        const archiveData = new Uint8Array(sevenZip.FS.readFile(`/${archiveName}`));
+
+        // Write archive to real FS
+        const archiveHandle = await targetDirectory.getFileHandle(archiveName, { create: true });
+        const writable = await archiveHandle.createWritable();
+        try {
+            await writable.write(archiveData);
+        } finally {
+            await writable.close();
+        }
+
+        // Cleanup virtual FS to free memory
+        const filesInFolder = sevenZip.FS.readdir(`/${folderName}`).filter(f => f !== '.' && f !== '..'); // skip special entries
+        for (const file of filesInFolder) {
+            sevenZip.FS.unlink(`${`/${folderName}`}/${file}`);
+        }
+        sevenZip.FS.rmdir(`/${folderName}`);
+        sevenZip.FS.unlink(`/${archiveName}`);
+    }
+}

--- a/web/src/i18n/ILocale.ts
+++ b/web/src/i18n/ILocale.ts
@@ -258,6 +258,7 @@ export enum EngineResourceKey {
     Settings_Global_MangaExportFormatInfo = 'Settings_Global_MangaExportFormatInfo',
     Settings_Global_MangaExportFormat_FolderWithImages = 'Settings_Global_MangaExportFormat_FolderWithImages',
     Settings_Global_MangaExportFormat_ComicBookArchive = 'Settings_Global_MangaExportFormat_ComicBookArchive',
+    Settings_Global_MangaExportFormat_SevenZipArchive = 'Settings_Global_MangaExportFormat_SevenZipArchive',
     Settings_Global_MangaExportFormat_ElectronicPublication = 'Settings_Global_MangaExportFormat_ElectronicPublication',
     Settings_Global_MangaExportFormat_PortableDocumentFormat = 'Settings_Global_MangaExportFormat_PortableDocumentFormat',
     Settings_Global_DescramblingFormat = 'Settings_Global_DescramblingFormat',

--- a/web/src/i18n/locales/en_US.ts
+++ b/web/src/i18n/locales/en_US.ts
@@ -167,6 +167,7 @@ const translations: VariantResource = {
   Settings_Global_MangaExportFormatInfo: 'The container format to store the downloaded content for mangas/comics',
   Settings_Global_MangaExportFormat_FolderWithImages: 'Folder with Images',
   Settings_Global_MangaExportFormat_ComicBookArchive: 'Comic Book Archive (*.cbz)',
+  Settings_Global_MangaExportFormat_SevenZipArchive: '7z Archive (*.7z)',
   Settings_Global_MangaExportFormat_ElectronicPublication: 'E-Book Publication (*.epub)',
   Settings_Global_MangaExportFormat_PortableDocumentFormat: 'Portable Document Format (*.pdf)',
   Settings_Global_DescramblingFormat: 'De-Scrambling Format',


### PR DESCRIPTION
I like 7z for its more compact compression than zip (LZMA2 vs deflate) so I added a new exporter based on 7z-wasm. The code was tested on both arch linux and windows 11. The automated npm tests also appear to still pass.


Possible issues:
Stores chapter data in a virtual filesystem in memory and might not work on computers with minimal RAM.
Adds a new line that will need to be translated into languages other than English.
Uses C7Z as the typename which might wrongly imply a comic.xml file exists (similar to CBZ).