### PR TITLE
fix : remove unicode format characters from filenames

### DIFF
--- a/web/src/engine/StorageController.ts
+++ b/web/src/engine/StorageController.ts
@@ -35,9 +35,13 @@ export function SanitizeFileName(name: string): string {
         '~': '～', //https://unicode-explorer.com/c/FF5E //File System API cannot handle trailing hyphens
     };
 
+    const patternControlCodes = /[\p{Cc}]/gu; // https://en.wikipedia.org/wiki/C0_and_C1_control_codes
+    const patternControlFormat = /[\p{Cf}]/gu; // https://www.compart.com/en/unicode/category/Cf
+
     // TODO: Reserved names? => CON, PRN, AUX, NUL, COM1, LPT1
     return name
-        .replace(/[\p{Cc}\p{Cf}]/gu, '')// https://en.wikipedia.org/wiki/C0_and_C1_control_codes, https://www.compart.com/en/unicode/category/Cf
+        .replace(patternControlCodes, '')
+        .replace(patternControlFormat, '')
         .replace(/./g, c => lookup[c] ?? c)
         .replace(/\s+$/, '')
         .trim()

--- a/web/src/engine/StorageController_test.ts
+++ b/web/src/engine/StorageController_test.ts
@@ -5,8 +5,12 @@ describe('StorageController', () => {
 
     describe('SanitizeFileName', () => {
 
-        it('Should replace forbidden characters', () => {
-            expect(SanitizeFileName('\u200b< > : " / \\ | ? * ~\u00ad')).toBe('＜ ＞ ꞉ ＂ ／ ＼ ｜ ？ ＊ ～');
+        it.each([
+            ['\u0009\u000aHello\u000d World', 'Hello World'],
+            ['< > : " / \\ | ? * ~', '＜ ＞ ꞉ ＂ ／ ＼ ｜ ？ ＊ ～'],
+            ['\u200bHakuneko \u00adIs\uFEFF Awesome 😎', 'Hakuneko Is Awesome 😎'],
+        ])('Should replace control characters, forbidden characters and control format characters', (input, expected) => {
+            expect(SanitizeFileName(input)).toBe(expected);
         });
 
         it.each([


### PR DESCRIPTION
Case : Mangafire 
Manga: Fate/Stay night, heaven feels
Chapter : 40, english

Chapter name got https://unicode-explorer.com/c/200B in its name. This code is accepted by Operating System (Windows 11) but NOT by FileSystem API, causing an error in ImageDirectoryExporter.export.

While we are at it, lets remove all https://www.compart.com/en/unicode/category/Cf. This is what this pr IS DOING