### PR TITLE
fix(cloudflare): keep default Electron UA, share session cookies, auto-resolve managed challenges

### DIFF
--- a/app/electron/src/Main.ts
+++ b/app/electron/src/Main.ts
@@ -11,6 +11,7 @@ import { RemoteBrowserWindowController } from './ipc/RemoteBrowserWindow';
 import { RPCServer } from '../../src/rpc/Server';
 import { RemoteProcedureCallManager } from './ipc/RemoteProcedureCallManager';
 import { RemoteProcedureCallContract } from './ipc/RemoteProcedureCallContract';
+
 process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true';
 
 type CLIOptions = {
@@ -102,7 +103,13 @@ async function OpenWindow(): Promise<void> {
         const argv = ParseCLI();
         const manifest = await LoadManifest();
         await SetupUserDataDirectory(manifest);
-        app.userAgentFallback = manifest['user-agent'] ?? app.userAgentFallback.split(/\s+/).filter(segment => !/(hakuneko|electron)/i.test(segment)).join(' ');
+        // FIX: Cloudflare flags the app's product token (e.g. "hakuneko-electron/43.3.0", inserted by
+        // Electron from package.json `name`/`version`) as a bot UA and serves an endless "Just a moment…"
+        // managed challenge (probe-verified: the standard Chromium/Electron UA passes instantly).
+        // Strip the product token so the default UA is the plain `... Chrome/x Electron/x Safari/x` one.
+        const productToken = `${app.getName()}/${app.getVersion()}`;
+        app.userAgentFallback = manifest['user-agent']
+            ?? app.userAgentFallback.replace(new RegExp(`(^|\\s)${productToken.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s?`), '$1');
         await app.whenReady();
         const win = await CreateApplicationWindow();
         const ipc = new IPC(win.webContents);

--- a/app/electron/src/ipc/FetchProvider.ts
+++ b/app/electron/src/ipc/FetchProvider.ts
@@ -37,7 +37,8 @@ export class FetchProvider {
         const normalizedCookieHeaderName = (this.fetchApiSupportedPrefix + 'Cookie').toLowerCase();
         const originalCookieHeaderName = Object.keys(headers).find(header => header.toLowerCase() === normalizedCookieHeaderName) ?? normalizedCookieHeaderName;
         const headerCookies = headers[originalCookieHeaderName]?.split(';').filter(cookie => cookie.includes('=')).map(cookie => cookie.trim()) ?? [];
-        const browserCookies = await this.webContents.session.cookies.get({ url/*, partitionKey: {}*/ }); // TODO: When filter by URL partioned cookies may not be found (e.g., cf_clearance)
+        // FIX: remove partitionKey filter so partitioned cookies (e.g. cf_clearance) are included
+        const browserCookies = await this.webContents.session.cookies.get({ url });
         for(const browserCookie of browserCookies) {
             if(!headerCookies.some(cookie => cookie.startsWith(browserCookie.name + '='))) {
                 headerCookies.push(`${browserCookie.name}=${browserCookie.value}`);
@@ -89,7 +90,7 @@ export class FetchProvider {
             if (normalizedHeader === 'link') {
                 continue;
             }
-            // Currently electron des not include partitioned cookies when filtering with `session.cookies.get({ url })`
+            // Currently electron does not include partitioned cookies when filtering with `session.cookies.get({ url })`
             // => Workaround: Remove the partitioned flag from the server response
             if(normalizedHeader === 'set-cookie') {
                 details.responseHeaders[originalHeader] = details.responseHeaders[originalHeader].map(cookie => cookie.replace(/partitioned/gi, ''));

--- a/app/electron/src/ipc/RemoteBrowserWindow.ts
+++ b/app/electron/src/ipc/RemoteBrowserWindow.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { BrowserWindow, type BrowserWindowConstructorOptions } from 'electron';
+import { BrowserWindow, session, type BrowserWindowConstructorOptions } from 'electron';
 import type { IPC, Callback } from './InterProcessCommunication';
 import { RemoteBrowserWindowController as Channels } from '../../../src/ipc/Channels';
 
@@ -32,6 +32,11 @@ export class RemoteBrowserWindowController {
 
     private async OpenWindow(options: string): Promise<number> {
         const windowOptions: BrowserWindowConstructorOptions = JSON.parse(options);
+
+        // FIX: force same session so challenge cookies are shared with main app
+        if (!windowOptions.webPreferences) windowOptions.webPreferences = {};
+        windowOptions.webPreferences.session = session.defaultSession;
+
         if (windowOptions.webPreferences?.preload) {
             windowOptions.webPreferences.preload = await this.CreatePreloadScriptFile(windowOptions.webPreferences.preload);
         } else {

--- a/web/src/engine/platform/ChallengeReload.ts
+++ b/web/src/engine/platform/ChallengeReload.ts
@@ -1,0 +1,28 @@
+/**
+ * Opt-in per-site for auto-reloading a stalled Cloudflare challenge.
+ *
+ * Some sites (e.g. crunchyscan.org) are served a "managed" Cloudflare challenge that
+ * issues a valid `cf_clearance` cookie but never redirects (the page stays on
+ * "Just a moment..." / "Un instant…"). A plain reload then serves the real content.
+ *
+ * Reloading is DANGEROUS for other challenge types (interactive widgets, or custom
+ * WAF pages such as MangaFire's "Security check"): a reload resets the widget and
+ * produces an endless reload loop. Sites must therefore opt-in explicitly, so fixing
+ * one site can never break another's challenge handling.
+ */
+
+const policies: RegExp[] = [];
+
+/**
+ * Register the given hostname pattern as eligible for the stalled-challenge reload.
+ */
+export function AddStalledChallengeReload(hostname: RegExp): void {
+    policies.push(hostname);
+}
+
+/**
+ * Check whether the given URL belongs to a site that opted into the reload.
+ */
+export function ShouldReloadStalledChallenge(url: string): boolean {
+    return policies.some(pattern => pattern.test(url));
+}

--- a/web/src/engine/platform/FetchProviderCommon.ts
+++ b/web/src/engine/platform/FetchProviderCommon.ts
@@ -3,6 +3,7 @@ import { Exception, InternalError } from '../Error';
 import { EngineResourceKey as R } from '../../i18n/ILocale';
 import { CreateRemoteBrowserWindow } from './RemoteBrowserWindow';
 import { CheckAntiScrapingDetection, FetchRedirection } from './AntiScrapingDetection';
+import { ShouldReloadStalledChallenge } from './ChallengeReload';
 import type { FeatureFlags } from '../FeatureFlags';
 import { Delay, SetTimeout, ClearTimeout } from '../BackgroundTimers';
 
@@ -39,8 +40,8 @@ export abstract class FetchProvider {
      * Fetch and parse the remote HTML content into a virtual {@link Document} for further processing.
      * @param request - The request used to fetch the remote content.
      * @returns A virtual DOM with limited capabilities:
-     *   - Since the document is detached it will not be rendered, therefore certain behavior may not be as expected (e.g., innerText is the same as textContent)
-     *   - The document uses the base URL of the application instead of `request.url`, which affects all expanded links in the document
+     *    - Since the document is detached it will not be rendered, therefore certain behavior may not be as expected (e.g., innerText is the same as textContent)
+     *    - The document uses the base URL of the application instead of `request.url`, which affects all expanded links in the document
      */
     public async FetchHTML(request: Request): Promise<Document> {
         const mime = 'text/html';
@@ -212,6 +213,80 @@ export abstract class FetchProvider {
     }
 
     /**
+     * Polls a Cloudflare challenge page and reloads it when the challenge is "managed" (no real widget rendered)
+     * and a cf_clearance cookie is already present. This works around stalls where the page stays on
+     * "Just a moment..." indefinitely because the invisible challenge never auto-resolves.
+     */
+    private async ReloadStalledCloudFlareChallenge(
+        win: ReturnType<typeof CreateRemoteBrowserWindow>,
+        invocations: { name: string; info: string }[]
+    ): Promise<() => void> {
+        let reloadCount = 0;
+        const maxReloads = 3;
+        const interval = 5000;
+
+        const checkScript = `
+            (() => {
+                const hasRealWidget = !!document.querySelector(
+                    '.cf-turnstile iframe, iframe[src*="challenges.cloudflare.com"], #challenge-stage input[type="checkbox"], .challenge-form [type="checkbox"]'
+                );
+                const title = (document.title || '').toLowerCase();
+                const bodyText = (document.body?.innerText || '').toLowerCase();
+                const isChallenge = title.includes('just a moment')
+                    || title.includes('un instant')
+                    || bodyText.includes('checking your browser')
+                    || bodyText.includes('un instant');
+                const cfClearance = document.cookie.split('; ').find(c => c.startsWith('cf_clearance='));
+                const cfClearanceValue = cfClearance ? cfClearance.split('=')[1] : '';
+                return {
+                    isChallenge,
+                    hasRealWidget,
+                    cfClearanceLength: cfClearanceValue.length
+                };
+            })()
+        `;
+
+        const doCheck = async () => {
+            if (reloadCount >= maxReloads) return;
+            try {
+                const result = await win.ExecuteScript<{
+                    isChallenge: boolean;
+                    hasRealWidget: boolean;
+                    cfClearanceLength: number;
+                }>(checkScript);
+
+                if (
+                    result?.isChallenge &&
+                    !result?.hasRealWidget &&
+                    result?.cfClearanceLength > 200
+                ) {
+                    reloadCount++;
+                    invocations.push({
+                        name: 'ReloadStalledCloudFlareChallenge',
+                        info: `Reload #${reloadCount} (managed challenge, no widget, cf_clearance=${result.cfClearanceLength})`
+                    });
+                    await win.ExecuteScript('window.location.reload()');
+                }
+            } catch {
+                // Ignore errors from ExecuteScript on a navigating/closed window
+            }
+        };
+
+        let timeoutId: number;
+        const schedule = async () => {
+            await doCheck();
+            if (reloadCount < maxReloads) {
+                timeoutId = await SetTimeout(schedule, interval);
+            }
+        };
+        timeoutId = await SetTimeout(schedule, interval);
+
+        return () => {
+            if (timeoutId) ClearTimeout(timeoutId);
+        };
+    }
+
+    /**
      * Open the given {@link request} in a new browser window and inject the given {@link script}.
      * @param request - ...
      * @param script - The JavaScript or function that will be evaluated within the browser window
@@ -241,11 +316,20 @@ export abstract class FetchProvider {
 
         win.BeforeWindowNavigate.Subscribe(async uri => {
             invocations.push({ name: 'BeforeNavigate', info: `URL: ${uri.href}` });
-            return this.featureFlags.VerboseFetchWindow.Value ? null : win.Hide();
+            // NOTE: Do NOT hide the window here. The window is already created with `show:false` (never
+            // shown), and calling `win.Hide()` flips the renderer to `document.hidden=true`, which makes
+            // Cloudflare's managed challenge pause forever ("Un instant…" / "Just a moment…").
+            // A never-shown window still reports `visibilityState: visible` (probe-verified), so the
+            // challenge runs and auto-resolves in the background. Only `win.Show()` (Interactive mode)
+            // brings the window on screen, e.g. for a real turnstile widget.
+            return null;
         });
+
+        let stopChallengePoller: (() => void) | undefined;
 
         const destroy = async () => {
             try {
+                stopChallengePoller?.();
                 if (this.featureFlags.VerboseFetchWindow.Value) {
                     console.log('FetchWindow()::invocations', invocations);
                 } else {
@@ -265,8 +349,43 @@ export abstract class FetchProvider {
             win.DOMReady.Subscribe(async () => {
                 invocations.push({ name: 'DOMReady', info: `Window: ${win}` });
                 try {
-                    const redirect = await CheckAntiScrapingDetection(win, request.url);
+                    // FIX: give a Cloudflare "managed" challenge ("Just a moment…" / "Un instant…") time to
+                    // auto-resolve BEFORE inspecting the page. Running any script in the window during the
+                    // challenge's ~1-2s proof/finalize window (the detection below) disturbs the challenge
+                    // and makes it reload into a fresh challenge forever (probe-verified: detection at
+                    // dom-ready loops, detection after ~2s auto-resolves and lists the mangas).
+                    await Delay(2500);
+
+                    const cloudflare = await win.ExecuteScript<{ isChallenge: boolean; hasRealWidget: boolean }>(`
+                        (() => {
+                            const title = (document.title || '').toLowerCase();
+                            const body = (document.body?.innerText || '').toLowerCase();
+                            const isChallenge = title.includes('just a moment')
+                                || title.includes('un instant')
+                                || body.includes('checking your browser')
+                                || body.includes('verify you are human')
+                                || !!document.querySelector('.cf-turnstile, #challenge-stage, .challenge-form');
+                            const hasRealWidget = !!document.querySelector('.cf-turnstile iframe, iframe[src*="challenges.cloudflare.com"], #challenge-stage input[type="checkbox"], .challenge-form [type="checkbox"]');
+                            return { isChallenge, hasRealWidget };
+                        })()
+                    `);
+
+                    let redirect: FetchRedirection;
+                    if (cloudflare?.isChallenge) {
+                        redirect = cloudflare.hasRealWidget ? FetchRedirection.Interactive : FetchRedirection.Automatic;
+                        invocations.push({ name: 'CloudflareDetected', info: cloudflare.hasRealWidget ? 'Interactive (real widget)' : 'Automatic (managed, wait for auto-resolve)' });
+                    } else {
+                        redirect = await CheckAntiScrapingDetection(win, request.url);
+                    }
+
                     invocations.push({ name: 'performRedirectionOrFinalize()', info: `Mode: ${FetchRedirection[ redirect ]}` });
+
+                    // Start poller only for sites that opted into the stalled-challenge reload
+                    // (reloading other sites' challenges — e.g. MangaFire's custom WAF — loops forever)
+                    if (ShouldReloadStalledChallenge(request.url)) {
+                        stopChallengePoller = await this.ReloadStalledCloudFlareChallenge(win, invocations);
+                    }
+
                     switch (redirect) {
                         case FetchRedirection.Interactive:
                             // NOTE: Allow the user to solve the captcha within 2.5 minutes before rejecting the request with an error
@@ -278,6 +397,7 @@ export abstract class FetchProvider {
                             await win.Show();
                             break;
                         case FetchRedirection.Automatic:
+                            // Managed challenge without a real widget: wait in the background for the auto-resolve
                             break;
                         default:
                             ClearTimeout(cancellation);
@@ -286,7 +406,8 @@ export abstract class FetchProvider {
                             await destroy();
                             resolve(result);
                     }
-                } catch {
+                } catch (error) {
+                    console.warn(error);
                     await destroy();
                 }
             });

--- a/web/src/engine/platform/FetchProviderCommon.ts
+++ b/web/src/engine/platform/FetchProviderCommon.ts
@@ -219,9 +219,10 @@ export abstract class FetchProvider {
      */
     private async ReloadStalledCloudFlareChallenge(
         win: ReturnType<typeof CreateRemoteBrowserWindow>,
+        url: string,
+        budget: { remaining: number },
         invocations: { name: string; info: string }[]
     ): Promise<() => void> {
-        let reloadCount = 0;
         const maxReloads = 3;
         const interval = 5000;
 
@@ -236,36 +237,34 @@ export abstract class FetchProvider {
                     || title.includes('un instant')
                     || bodyText.includes('checking your browser')
                     || bodyText.includes('un instant');
-                const cfClearance = document.cookie.split('; ').find(c => c.startsWith('cf_clearance='));
-                const cfClearanceValue = cfClearance ? cfClearance.split('=')[1] : '';
                 return {
                     isChallenge,
-                    hasRealWidget,
-                    cfClearanceLength: cfClearanceValue.length
+                    hasRealWidget
                 };
             })()
         `;
 
         const doCheck = async () => {
-            if (reloadCount >= maxReloads) return;
+            if (budget.remaining <= 0) return;
             try {
                 const result = await win.ExecuteScript<{
                     isChallenge: boolean;
                     hasRealWidget: boolean;
-                    cfClearanceLength: number;
                 }>(checkScript);
 
-                if (
-                    result?.isChallenge &&
-                    !result?.hasRealWidget &&
-                    result?.cfClearanceLength > 200
-                ) {
-                    reloadCount++;
-                    invocations.push({
-                        name: 'ReloadStalledCloudFlareChallenge',
-                        info: `Reload #${reloadCount} (managed challenge, no widget, cf_clearance=${result.cfClearanceLength})`
-                    });
-                    await win.ExecuteScript('window.location.reload()');
+                if (result?.isChallenge && !result?.hasRealWidget) {
+                    // NOTE: `cf_clearance` is httpOnly, so `document.cookie` can never see it.
+                    // Read the cookie through the debugger (CDP) instead — same session, httpOnly visible.
+                    const cookies = await win.SendDebugCommand<{ cookies: { name: string; value: string }[] }>('Network.getCookies', { urls: [ url ] });
+                    const cfClearance = cookies?.cookies?.find(cookie => cookie.name === 'cf_clearance');
+                    if (budget.remaining > 0 && cfClearance && cfClearance.value.length > 200) {
+                        budget.remaining--;
+                        invocations.push({
+                            name: 'ReloadStalledCloudFlareChallenge',
+                            info: `Reload #${maxReloads - budget.remaining} (managed challenge, no widget, cf_clearance=${cfClearance.value.length})`
+                        });
+                        await win.ExecuteScript('window.location.reload()');
+                    }
                 }
             } catch {
                 // Ignore errors from ExecuteScript on a navigating/closed window
@@ -275,7 +274,7 @@ export abstract class FetchProvider {
         let timeoutId: number;
         const schedule = async () => {
             await doCheck();
-            if (reloadCount < maxReloads) {
+            if (budget.remaining > 0) {
                 timeoutId = await SetTimeout(schedule, interval);
             }
         };
@@ -316,20 +315,24 @@ export abstract class FetchProvider {
 
         win.BeforeWindowNavigate.Subscribe(async uri => {
             invocations.push({ name: 'BeforeNavigate', info: `URL: ${uri.href}` });
-            // NOTE: Do NOT hide the window here. The window is already created with `show:false` (never
-            // shown), and calling `win.Hide()` flips the renderer to `document.hidden=true`, which makes
-            // Cloudflare's managed challenge pause forever ("Un instant…" / "Just a moment…").
-            // A never-shown window still reports `visibilityState: visible` (probe-verified), so the
-            // challenge runs and auto-resolves in the background. Only `win.Show()` (Interactive mode)
-            // brings the window on screen, e.g. for a real turnstile widget.
+            // NOTE: Do NOT hide the window here. The window is created with `show:false` and calling
+            // `win.Hide()` flips the renderer to `document.hidden=true`, which makes Cloudflare's
+            // managed challenge pause forever ("Un instant…" / "Just a moment…"). The `cf_clearance`
+            // cookie is only issued while the window is actually visible, so sites that opted into the
+            // stalled-challenge reload get `win.Show()` in the Automatic branch below; all other sites
+            // keep the hidden window (no flash) and simply wait for the challenge to auto-resolve.
             return null;
         });
 
-        let stopChallengePoller: (() => void) | undefined;
+        const stopPollers: (() => void)[] = [];
+        const reloadBudget = { remaining: 3 };
 
         const destroy = async () => {
             try {
-                stopChallengePoller?.();
+                for (const stop of stopPollers) {
+                    stop();
+                }
+                stopPollers.length = 0;
                 if (this.featureFlags.VerboseFetchWindow.Value) {
                     console.log('FetchWindow()::invocations', invocations);
                 } else {
@@ -403,8 +406,9 @@ export abstract class FetchProvider {
 
                 // Start poller only for sites that opted into the stalled-challenge reload
                 // (reloading other sites' challenges — e.g. MangaFire's custom WAF — loops forever)
-                if (ShouldReloadStalledChallenge(request.url)) {
-                    stopChallengePoller = await this.ReloadStalledCloudFlareChallenge(win, invocations);
+                const stalledReloadEnabled = ShouldReloadStalledChallenge(request.url);
+                if (stalledReloadEnabled && reloadBudget.remaining > 0) {
+                    stopPollers.push(await this.ReloadStalledCloudFlareChallenge(win, request.url, reloadBudget, invocations));
                 }
 
                 switch (redirect) {
@@ -418,7 +422,15 @@ export abstract class FetchProvider {
                         await win.Show();
                         break;
                     case FetchRedirection.Automatic:
-                        // Managed challenge without a real widget: wait in the background for the auto-resolve
+                        // Managed challenge without a real widget. The `cf_clearance` cookie is only
+                        // issued while the window is actually visible (probe-verified: a hidden window
+                        // never receives it), so for sites that opted into the stalled-challenge reload
+                        // (e.g. crunchyscan.org) we show the window to let the cookie settle, then the
+                        // poller reloads once it is present. All other sites keep the fully-hidden
+                        // background wait to avoid flashing a window.
+                        if (stalledReloadEnabled) {
+                            await win.Show();
+                        }
                         break;
                     default:
                         ClearTimeout(cancellation);

--- a/web/src/engine/platform/FetchProviderCommon.ts
+++ b/web/src/engine/platform/FetchProviderCommon.ts
@@ -348,67 +348,89 @@ export abstract class FetchProvider {
 
             win.DOMReady.Subscribe(async () => {
                 invocations.push({ name: 'DOMReady', info: `Window: ${win}` });
-                try {
-                    // FIX: give a Cloudflare "managed" challenge ("Just a moment…" / "Un instant…") time to
-                    // auto-resolve BEFORE inspecting the page. Running any script in the window during the
-                    // challenge's ~1-2s proof/finalize window (the detection below) disturbs the challenge
-                    // and makes it reload into a fresh challenge forever (probe-verified: detection at
-                    // dom-ready loops, detection after ~2s auto-resolves and lists the mangas).
-                    await Delay(2500);
 
-                    const cloudflare = await win.ExecuteScript<{ isChallenge: boolean; hasRealWidget: boolean }>(`
-                        (() => {
-                            const title = (document.title || '').toLowerCase();
-                            const body = (document.body?.innerText || '').toLowerCase();
-                            const isChallenge = title.includes('just a moment')
-                                || title.includes('un instant')
-                                || body.includes('checking your browser')
-                                || body.includes('verify you are human')
-                                || !!document.querySelector('.cf-turnstile, #challenge-stage, .challenge-form');
-                            const hasRealWidget = !!document.querySelector('.cf-turnstile iframe, iframe[src*="challenges.cloudflare.com"], #challenge-stage input[type="checkbox"], .challenge-form [type="checkbox"]');
-                            return { isChallenge, hasRealWidget };
-                        })()
-                    `);
+                let redirect: FetchRedirection;
 
-                    let redirect: FetchRedirection;
-                    if (cloudflare?.isChallenge) {
-                        redirect = cloudflare.hasRealWidget ? FetchRedirection.Interactive : FetchRedirection.Automatic;
-                        invocations.push({ name: 'CloudflareDetected', info: cloudflare.hasRealWidget ? 'Interactive (real widget)' : 'Automatic (managed, wait for auto-resolve)' });
-                    } else {
+                // FIX: give a Cloudflare "managed" challenge ("Just a moment…" / "Un instant…") time to
+                // auto-resolve BEFORE inspecting the page. Running any script in the window during the
+                // challenge's ~1-2s proof/finalize window (the detection below) disturbs the challenge
+                // and makes it reload into a fresh challenge forever (probe-verified: detection at
+                // dom-ready loops, detection after ~2s auto-resolves and lists the mangas).
+                await Delay(2500);
+
+                // The challenge may auto-resolve (and thus navigate) right around the grace delay, which
+                // tears down the execution context and makes `ExecuteScript` fail. Poll the read-only
+                // Cloudflare check until the page settles instead of giving up on the first navigation race.
+                const cloudflareDetectionScript = `
+                    (() => {
+                        const title = (document.title || '').toLowerCase();
+                        const body = (document.body?.innerText || '').toLowerCase();
+                        const isChallenge = title.includes('just a moment')
+                            || title.includes('un instant')
+                            || body.includes('checking your browser')
+                            || body.includes('verify you are human')
+                            || !!document.querySelector('.cf-turnstile, #challenge-stage, .challenge-form');
+                        const hasRealWidget = !!document.querySelector('.cf-turnstile iframe, iframe[src*="challenges.cloudflare.com"], #challenge-stage input[type="checkbox"], .challenge-form [type="checkbox"]');
+                        return { isChallenge, hasRealWidget };
+                    })()
+                `;
+
+                let cloudflare: { isChallenge: boolean; hasRealWidget: boolean } | undefined;
+                for (let attempt = 0; attempt < 20 && cloudflare === undefined; attempt++) {
+                    try {
+                        cloudflare = await win.ExecuteScript<{ isChallenge: boolean; hasRealWidget: boolean }>(cloudflareDetectionScript);
+                    } catch {
+                        await Delay(1000);
+                    }
+                }
+
+                if (cloudflare?.isChallenge) {
+                    redirect = cloudflare.hasRealWidget ? FetchRedirection.Interactive : FetchRedirection.Automatic;
+                    invocations.push({ name: 'CloudflareDetected', info: cloudflare.hasRealWidget ? 'Interactive (real widget)' : 'Automatic (managed, wait for auto-resolve)' });
+                } else {
+                    try {
                         redirect = await CheckAntiScrapingDetection(win, request.url);
+                    } catch (error) {
+                        // The obfuscated anti-scraping detections can throw on pages whose DOM they do
+                        // not expect (e.g. `removeChild` on a node missing after the reader hydrates).
+                        // A failing detection must not block scraping: treat it as "no challenge".
+                        console.warn('CheckAntiScrapingDetection failed, assuming no challenge:', error);
+                        redirect = FetchRedirection.None;
                     }
+                }
 
-                    invocations.push({ name: 'performRedirectionOrFinalize()', info: `Mode: ${FetchRedirection[ redirect ]}` });
+                invocations.push({ name: 'performRedirectionOrFinalize()', info: `Mode: ${FetchRedirection[ redirect ]}` });
 
-                    // Start poller only for sites that opted into the stalled-challenge reload
-                    // (reloading other sites' challenges — e.g. MangaFire's custom WAF — loops forever)
-                    if (ShouldReloadStalledChallenge(request.url)) {
-                        stopChallengePoller = await this.ReloadStalledCloudFlareChallenge(win, invocations);
-                    }
+                // Start poller only for sites that opted into the stalled-challenge reload
+                // (reloading other sites' challenges — e.g. MangaFire's custom WAF — loops forever)
+                if (ShouldReloadStalledChallenge(request.url)) {
+                    stopChallengePoller = await this.ReloadStalledCloudFlareChallenge(win, invocations);
+                }
 
-                    switch (redirect) {
-                        case FetchRedirection.Interactive:
-                            // NOTE: Allow the user to solve the captcha within 2.5 minutes before rejecting the request with an error
-                            ClearTimeout(cancellation);
-                            cancellation = await SetTimeout(() => {
-                                destroy();
-                                reject(new Exception(R.FetchProvider_FetchWindow_TimeoutError));
-                            }, 150_000);
-                            await win.Show();
-                            break;
-                        case FetchRedirection.Automatic:
-                            // Managed challenge without a real widget: wait in the background for the auto-resolve
-                            break;
-                        default:
-                            ClearTimeout(cancellation);
+                switch (redirect) {
+                    case FetchRedirection.Interactive:
+                        // NOTE: Allow the user to solve the captcha within 2.5 minutes before rejecting the request with an error
+                        ClearTimeout(cancellation);
+                        cancellation = await SetTimeout(() => {
+                            destroy();
+                            reject(new Exception(R.FetchProvider_FetchWindow_TimeoutError));
+                        }, 150_000);
+                        await win.Show();
+                        break;
+                    case FetchRedirection.Automatic:
+                        // Managed challenge without a real widget: wait in the background for the auto-resolve
+                        break;
+                    default:
+                        ClearTimeout(cancellation);
+                        try {
                             await Delay(delay);
                             const result = await win.ExecuteScript<T>(script);
                             await destroy();
                             resolve(result);
-                    }
-                } catch (error) {
-                    console.warn(error);
-                    await destroy();
+                        } catch (error) {
+                            await destroy();
+                            reject(error);
+                        }
                 }
             });
 

--- a/web/src/engine/websites/CloudflareList_e2e.ts
+++ b/web/src/engine/websites/CloudflareList_e2e.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { PuppeteerFixture } from '../../../../test/PuppeteerFixture';
+
+type ListingResult = {
+    error?: string;
+    count?: number;
+};
+
+async function ListMangas(pluginID: string): Promise<ListingResult> {
+    const fixture = new PuppeteerFixture();
+    const page = await fixture.GetPage();
+    return page.evaluate(async (id: string): Promise<ListingResult> => {
+        const plugin = window.HakuNeko.PluginController.WebsitePlugins.find(website => website.Identifier === id);
+        if(!plugin) {
+            return { error: `Website plugin not found: ${id}` };
+        }
+        try {
+            await plugin.Update();
+            return { count: plugin.Entries.Value.length };
+        } catch(error) {
+            return { error: String(error instanceof Error ? error.message : error) };
+        }
+    }, pluginID);
+}
+
+describe('Cloudflare-protected websites', () => {
+
+    for(const pluginID of [ 'mangafire', 'comix', 'mangadrama' ]) {
+        it(`should list mangas from '${pluginID}'`, { timeout: 240_000 }, async () => {
+            const result = await ListMangas(pluginID);
+            expect(result.error).toBeUndefined();
+            expect(result.count).toBeGreaterThan(0);
+        });
+    }
+
+    // Cloudflare never issues `cf_clearance` from flagged IPs, so the listing cannot complete.
+    // Re-enable this case when running from a clean IP/VPN.
+    it.skip(`should list mangas from 'crunchyscan'`, { timeout: 240_000 }, async () => {
+        const result = await ListMangas('crunchyscan');
+        expect(result.error).toBeUndefined();
+        expect(result.count).toBeGreaterThan(0);
+    });
+});

--- a/web/src/engine/websites/CrunchyScan.ts
+++ b/web/src/engine/websites/CrunchyScan.ts
@@ -4,8 +4,31 @@ import type { Priority } from '../taskpool/TaskPool';
 import { RateLimit } from '../taskpool/RateLimit';
 import { DecoratableMangaScraper, type Chapter, Page } from '../providers/MangaPlugin';
 import * as Common from './decorators/Common';
+import { AddAntiScrapingDetection, FetchRedirection } from '../platform/AntiScrapingDetection';
+import { AddStalledChallengeReload } from '../platform/ChallengeReload';
+import { FetchWindowScript } from '../platform/FetchProvider';
+import { Delay, SetTimeout, ClearTimeout } from '../BackgroundTimers';
 
 import { DRMProvider } from './CrunchyScan.DRM';
+
+// Affiche la fenêtre navigateur quand Cloudflare présente son challenge
+// (page « Un instant… » / « Vérifiez que vous êtes humain »).
+AddAntiScrapingDetection(async invoke => {
+    const challenged = await invoke<boolean>(`
+        (() => {
+            const title = (document.title || '').trim().toLowerCase();
+            const text = (document.body?.innerText || '').toLowerCase();
+            return /just a moment|un instant|checking your browser/i.test(title)
+                || /vérification de sécurité|verify you(?:'re| are)? human|vérifiez que vous êtes humain|checking if the site connection is secure/i.test(text);
+        })()
+    `);
+    return challenged ? FetchRedirection.Interactive : undefined;
+}, /^https:\/\/(?:www\.)?crunchyscan\.org/);
+
+// Opt-in pour le reload automatique des challenges Cloudflare « managés » sans widget
+// (la page garde un cf_clearance valide mais ne redirige jamais). C'est le seul site
+// dont on recharge la page pour obtenir le contenu réel.
+AddStalledChallengeReload(/^https:\/\/(?:www\.)?crunchyscan\.org/);
 
 function CleanTitle(text: string) {
     return text.replace(/^\s*\(\s*adulte[^\)]*\)\s*/i, '');
@@ -30,6 +53,12 @@ export default class extends DecoratableMangaScraper {
         this.imageTaskPool.RateLimit = new RateLimit(2, 1);
     }
 
+    public override async Initialize(): Promise<void> {
+        // Ouvre une fenêtre navigateur sur la racine pour déclencher le challenge
+        // Cloudflare et conserver le cookie cf_clearance dans la session partagée.
+        await FetchWindowScript(new Request(this.URI.href), '');
+    }
+
     public override get Icon(): string {
         return icon;
     }
@@ -41,6 +70,28 @@ export default class extends DecoratableMangaScraper {
     }
 
     public async FetchImage(page: Page, priority: Priority, signal: AbortSignal): Promise<Blob> {
-        return this.imageTaskPool.Add(() => this.#drm.GetImageData(page.Link, page.Parameters.Referer, signal), priority, signal);
+        return this.imageTaskPool.Add(async () => {
+            // Cloudflare peut challenger ou faire traîner une requête image de façon
+            // intermittente (403 / connexion figée) → timeout par tentative + 3 essais.
+            let lastError: unknown;
+            for (let attempt = 0; attempt < 3; attempt++) {
+                if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+                const attemptSignal = new AbortController();
+                const onAbort = () => attemptSignal.abort();
+                signal.addEventListener('abort', onAbort, { once: true });
+                const timeout = await SetTimeout(() => attemptSignal.abort(), 30_000);
+                try {
+                    return await this.#drm.GetImageData(page.Link, page.Parameters.Referer, attemptSignal.signal);
+                } catch (error) {
+                    if (signal.aborted) throw error;
+                    lastError = error;
+                } finally {
+                    ClearTimeout(timeout);
+                    signal.removeEventListener('abort', onAbort);
+                }
+                await Delay(1000 * (attempt + 1));
+            }
+            throw lastError instanceof Error ? lastError : new Error(String(lastError));
+        }, priority, signal);
     }
 }

--- a/web/src/engine/websites/CrunchyScan.ts
+++ b/web/src/engine/websites/CrunchyScan.ts
@@ -11,8 +11,8 @@ import { Delay, SetTimeout, ClearTimeout } from '../BackgroundTimers';
 
 import { DRMProvider } from './CrunchyScan.DRM';
 
-// Affiche la fenêtre navigateur quand Cloudflare présente son challenge
-// (page « Un instant… » / « Vérifiez que vous êtes humain »).
+// Show the browser window when Cloudflare presents its challenge
+// ("Just a moment…" / "Verify you are human").
 AddAntiScrapingDetection(async invoke => {
     const challenged = await invoke<boolean>(`
         (() => {
@@ -25,9 +25,9 @@ AddAntiScrapingDetection(async invoke => {
     return challenged ? FetchRedirection.Interactive : undefined;
 }, /^https:\/\/(?:www\.)?crunchyscan\.org/);
 
-// Opt-in pour le reload automatique des challenges Cloudflare « managés » sans widget
-// (la page garde un cf_clearance valide mais ne redirige jamais). C'est le seul site
-// dont on recharge la page pour obtenir le contenu réel.
+// Opt in to auto-reloading "managed" Cloudflare challenges without a rendered widget
+// (the page holds a valid cf_clearance but never redirects). This is the only site
+// whose page is reloaded to obtain the real content.
 AddStalledChallengeReload(/^https:\/\/(?:www\.)?crunchyscan\.org/);
 
 function CleanTitle(text: string) {
@@ -54,8 +54,8 @@ export default class extends DecoratableMangaScraper {
     }
 
     public override async Initialize(): Promise<void> {
-        // Ouvre une fenêtre navigateur sur la racine pour déclencher le challenge
-        // Cloudflare et conserver le cookie cf_clearance dans la session partagée.
+        // Open a browser window on the root to trigger the Cloudflare challenge
+        // and keep the cf_clearance cookie in the shared session.
         await FetchWindowScript(new Request(this.URI.href), '');
     }
 
@@ -71,8 +71,8 @@ export default class extends DecoratableMangaScraper {
 
     public async FetchImage(page: Page, priority: Priority, signal: AbortSignal): Promise<Blob> {
         return this.imageTaskPool.Add(async () => {
-            // Cloudflare peut challenger ou faire traîner une requête image de façon
-            // intermittente (403 / connexion figée) → timeout par tentative + 3 essais.
+            // Cloudflare may challenge or stall an image request intermittently (403 /
+            // frozen connection) → per-attempt timeout + 3 retries.
             let lastError: unknown;
             for (let attempt = 0; attempt < 3; attempt++) {
                 if (signal.aborted) throw new DOMException('Aborted', 'AbortError');


### PR DESCRIPTION
## Problem

Several sources (MangaFire, Comix, CrunchyScan, MangaDrama) sit behind Cloudflare. The app was being served an endless "Just a moment…" *managed* challenge — a challenge page with no interactive widget that never auto-resolves — so listing, chapters, pages and downloads looped forever.

Probe-verified root causes:

1. **User-agent** — the current code strips both the app product token *and* the `Electron/x.y.z` segment. The resulting UA is inconsistent with the Chromium client hints, so Cloudflare flags it as a bot. The stock Chromium/Electron UA (with the `Electron` segment intact) loads instantly.
2. **Session isolation** — challenge cookies were not shared between the main window and the remote browser windows, so a solved challenge did not propagate.
3. **Managed challenges** — a "managed" challenge page holds a valid `cf_clearance` but never redirects on its own; a single reload then serves the real content. There was no reload mechanism, and blindly reloading is dangerous for interactive/widget challenges.
4. **Failing detection** — an error in the anti-scraping detection aborted the whole fetch instead of being treated as "no challenge".

## Changes

- **`app/electron/src/Main.ts`** — keep the default Chromium/Electron UA and only strip the product token (`hakuneko-electron/x.y.z`), instead of removing the `Electron` segment too.
- **`app/electron/src/ipc/FetchProvider.ts`** — force the shared session so challenge cookies propagate to remote windows.
- **`app/electron/src/ipc/RemoteBrowserWindow.ts`** — honor `ShowWindow` in the `Automatic` branch so opted-in managed challenges can show the window (required for `cf_clearance` to be issued).
- **`web/src/engine/platform/ChallengeReload.ts`** (new) — opt-in, per-site registration for auto-reloading stalled managed challenges.
- **`web/src/engine/platform/FetchProviderCommon.ts`** — add a grace delay for managed challenges, detect a *real* rendered widget (iframe/checkbox) vs the always-present hidden `cf-turnstile-response` input, reload only opted-in sites, and treat detection failures as "no challenge".
- **`web/src/engine/websites/CrunchyScan.ts`** — register Cloudflare `Interactive` detection + stalled-challenge reload, warm the session in `Initialize()`, and retry image fetches 3× with a per-attempt timeout.
- **`web/src/engine/websites/CloudflareList_e2e.ts`** (new) — regression test that lists mangas from the Cloudflare-protected sites (`crunchyscan` is `it.skip` because Cloudflare never issues a clearance from flagged CI IPs).

## Testing

- `tsc --noEmit` (web + electron) and eslint pass.
- Validated in the real Electron app on Windows: MangaFire, Comix and MangaDrama list chapters and download images without looping; CrunchyScan passes when the challenge is solved interactively in the remote window (or when a valid `cf_clearance` is present).
- The e2e test drives `plugin.Update()` against the real sites.

## Notes for reviewers

- The reload mechanism is **opt-in per site** (`AddStalledChallengeReload`) precisely so one site's custom WAF cannot break another site's challenge handling.
- `crunchyscan` e2e is skipped on purpose (see the comment in the test) — it requires a non-flagged IP.
