### PR TITLE
perf(ui): virtualize chapter list, shard MediaLists, move fuzzy search to a worker

### DIFF
--- a/web/src/engine/MediaListStore.ts
+++ b/web/src/engine/MediaListStore.ts
@@ -40,15 +40,24 @@ export async function LoadMediaList(storage: StorageController, identifier: stri
 /**
  * Stores a media list as fixed-size shards and prunes stale shards (and the
  * legacy single-key blob) left behind by previous runs.
+ *
+ * Only the shards whose content actually changed (and any newly added shards)
+ * are rewritten, so refreshing a mostly-unchanged list does not re-clone and
+ * re-store tens of thousands of entries on every update.
  */
 export async function SaveMediaList(storage: StorageController, identifier: string, entries: MediaListEntry[]): Promise<void> {
     const previous = await storage.LoadPersistent<MediaListMeta>(Store.MediaLists, MetaKey(identifier));
-    const previousChunks = previous && typeof previous.chunks === 'number' ? previous.chunks : 0;
+    const sharded = previous && typeof previous.chunks === 'number';
+    const previousChunks = sharded ? previous.chunks : 0;
+    const previousEntries = sharded ? await LoadMediaList(storage, identifier) : [];
     const chunkCount = Math.ceil(entries.length / MediaListChunkSize);
 
     for (let index = 0; index < chunkCount; index++) {
         const chunk = entries.slice(index * MediaListChunkSize, (index + 1) * MediaListChunkSize);
-        await storage.SavePersistent(chunk, Store.MediaLists, ChunkKey(identifier, index));
+        const previousChunk = previousEntries.slice(index * MediaListChunkSize, (index + 1) * MediaListChunkSize);
+        if (!sharded || !ChunksEqual(chunk, previousChunk)) {
+            await storage.SavePersistent(chunk, Store.MediaLists, ChunkKey(identifier, index));
+        }
     }
     await storage.SavePersistent({ chunks: chunkCount }, Store.MediaLists, MetaKey(identifier));
 
@@ -59,4 +68,10 @@ export async function SaveMediaList(storage: StorageController, identifier: stri
     }
     stale.push(identifier);
     await storage.RemovePersistent(Store.MediaLists, ...stale);
+}
+
+/** True when two shards contain the same entries (identifier + title). */
+function ChunksEqual(left: MediaListEntry[], right: MediaListEntry[]): boolean {
+    if (left.length !== right.length) return false;
+    return left.every((entry, index) => entry.id === right[index]?.id && entry.title === right[index]?.title);
 }

--- a/web/src/engine/MediaListStore.ts
+++ b/web/src/engine/MediaListStore.ts
@@ -41,20 +41,23 @@ export async function LoadMediaList(storage: StorageController, identifier: stri
  * Stores a media list as fixed-size shards and prunes stale shards (and the
  * legacy single-key blob) left behind by previous runs.
  *
- * Only the shards whose content actually changed (and any newly added shards)
- * are rewritten, so refreshing a mostly-unchanged list does not re-clone and
- * re-store tens of thousands of entries on every update.
+ * Each shard is compared against its previously stored counterpart **one at a
+ * time**, so only the shards whose content actually changed (and any newly
+ * added shards) are rewritten — without ever materializing the whole previous
+ * list in memory. Refreshing a mostly-unchanged list therefore neither re-clones
+ * nor re-stores tens of thousands of entries on every update.
  */
 export async function SaveMediaList(storage: StorageController, identifier: string, entries: MediaListEntry[]): Promise<void> {
     const previous = await storage.LoadPersistent<MediaListMeta>(Store.MediaLists, MetaKey(identifier));
     const sharded = previous && typeof previous.chunks === 'number';
     const previousChunks = sharded ? previous.chunks : 0;
-    const previousEntries = sharded ? await LoadMediaList(storage, identifier) : [];
     const chunkCount = Math.ceil(entries.length / MediaListChunkSize);
 
     for (let index = 0; index < chunkCount; index++) {
         const chunk = entries.slice(index * MediaListChunkSize, (index + 1) * MediaListChunkSize);
-        const previousChunk = previousEntries.slice(index * MediaListChunkSize, (index + 1) * MediaListChunkSize);
+        const previousChunk = sharded
+            ? await storage.LoadPersistent<MediaListEntry[]>(Store.MediaLists, ChunkKey(identifier, index)) ?? []
+            : [];
         if (!sharded || !ChunksEqual(chunk, previousChunk)) {
             await storage.SavePersistent(chunk, Store.MediaLists, ChunkKey(identifier, index));
         }

--- a/web/src/engine/MediaListStore.ts
+++ b/web/src/engine/MediaListStore.ts
@@ -1,0 +1,62 @@
+import { Store, type StorageController } from './StorageController';
+
+export type MediaListEntry = { id: string; title: string };
+
+/**
+ * Number of entries stored per shard of a media list.
+ * Sharding avoids cloning/rewriting a single multi-thousand-entry blob on every
+ * load/save of the media list (e.g. ~70k entries for MangaFire).
+ */
+export const MediaListChunkSize = 1000;
+
+type MediaListMeta = { chunks: number };
+
+function MetaKey(identifier: string): string {
+    return `${identifier}#meta`;
+}
+
+function ChunkKey(identifier: string, index: number): string {
+    return `${identifier}#${index}`;
+}
+
+/**
+ * Loads a media list stored as fixed-size shards, falling back to the legacy
+ * single-key layout written by previous versions.
+ */
+export async function LoadMediaList(storage: StorageController, identifier: string): Promise<MediaListEntry[]> {
+    const meta = await storage.LoadPersistent<MediaListMeta>(Store.MediaLists, MetaKey(identifier));
+    if (meta && typeof meta.chunks === 'number') {
+        const chunks = await Promise.all(
+            Array.from({ length: meta.chunks }, (_, index) =>
+                storage.LoadPersistent<MediaListEntry[]>(Store.MediaLists, ChunkKey(identifier, index)),
+            ),
+        );
+        return chunks.flat();
+    }
+    // Legacy fallback: the whole list used to be stored under a single key.
+    return await storage.LoadPersistent<MediaListEntry[]>(Store.MediaLists, identifier) ?? [];
+}
+
+/**
+ * Stores a media list as fixed-size shards and prunes stale shards (and the
+ * legacy single-key blob) left behind by previous runs.
+ */
+export async function SaveMediaList(storage: StorageController, identifier: string, entries: MediaListEntry[]): Promise<void> {
+    const previous = await storage.LoadPersistent<MediaListMeta>(Store.MediaLists, MetaKey(identifier));
+    const previousChunks = previous && typeof previous.chunks === 'number' ? previous.chunks : 0;
+    const chunkCount = Math.ceil(entries.length / MediaListChunkSize);
+
+    for (let index = 0; index < chunkCount; index++) {
+        const chunk = entries.slice(index * MediaListChunkSize, (index + 1) * MediaListChunkSize);
+        await storage.SavePersistent(chunk, Store.MediaLists, ChunkKey(identifier, index));
+    }
+    await storage.SavePersistent({ chunks: chunkCount }, Store.MediaLists, MetaKey(identifier));
+
+    // Prune shards no longer needed (list shrank) and the legacy full-list key.
+    const stale: string[] = [];
+    for (let index = chunkCount; index < previousChunks; index++) {
+        stale.push(ChunkKey(identifier, index));
+    }
+    stale.push(identifier);
+    await storage.RemovePersistent(Store.MediaLists, ...stale);
+}

--- a/web/src/engine/MediaListStore_test.ts
+++ b/web/src/engine/MediaListStore_test.ts
@@ -45,6 +45,7 @@ function entries(count: number): { id: string; title: string }[] {
 
 class WriteCountingStorage extends MemoryStorage {
     public readonly writes = new Map<string, number>();
+    public readonly reads = new Map<string, number>();
 
     public override async SavePersistent<T>(value: T, store: Store, key?: string): Promise<void> {
         await super.SavePersistent(value, store, key);
@@ -52,6 +53,14 @@ class WriteCountingStorage extends MemoryStorage {
             const current = this.writes.get(key) ?? 0;
             this.writes.set(key, current + 1);
         }
+    }
+
+    public override async LoadPersistent<T>(store: Store, key?: string): Promise<T> {
+        if (key !== undefined) {
+            const current = this.reads.get(key) ?? 0;
+            this.reads.set(key, current + 1);
+        }
+        return super.LoadPersistent(store, key);
     }
 }
 
@@ -102,5 +111,19 @@ describe('MediaListStore', () => {
         expect(storage.writes.get('site#1')).toBe(2);
         expect(storage.writes.get('site#meta')).toBe(2);
         expect(await LoadMediaList(storage, 'site')).toEqual(updated);
+    });
+
+    it('Should compare shards one by one without loading the whole previous list', async () => {
+        const storage = new WriteCountingStorage();
+        await SaveMediaList(storage, 'site', entries(MediaListChunkSize * 3));
+        await SaveMediaList(storage, 'site', entries(MediaListChunkSize * 3));
+
+        // The legacy single-key blob must never be read during an update.
+        expect(storage.reads.get('site')).toBeUndefined();
+        // Each shard is read individually for comparison (meta + 3 shards).
+        expect(storage.reads.get('site#meta')).toBe(2);
+        expect(storage.reads.get('site#0')).toBe(1);
+        expect(storage.reads.get('site#1')).toBe(1);
+        expect(storage.reads.get('site#2')).toBe(1);
     });
 });

--- a/web/src/engine/MediaListStore_test.ts
+++ b/web/src/engine/MediaListStore_test.ts
@@ -43,6 +43,18 @@ function entries(count: number): { id: string; title: string }[] {
     return Array.from({ length: count }, (_, index) => ({ id: `manga-${index}`, title: `Manga ${index}` }));
 }
 
+class WriteCountingStorage extends MemoryStorage {
+    public readonly writes = new Map<string, number>();
+
+    public override async SavePersistent<T>(value: T, store: Store, key?: string): Promise<void> {
+        await super.SavePersistent(value, store, key);
+        if (key !== undefined) {
+            const current = this.writes.get(key) ?? 0;
+            this.writes.set(key, current + 1);
+        }
+    }
+}
+
 describe('MediaListStore', () => {
 
     it('Should round-trip a multi-chunk list in order', async () => {
@@ -72,5 +84,23 @@ describe('MediaListStore', () => {
         await SaveMediaList(storage, 'empty', entries(MediaListChunkSize * 2));
         await SaveMediaList(storage, 'empty', []);
         expect(await LoadMediaList(storage, 'empty')).toEqual([]);
+    });
+
+    it('Should only rewrite shards whose content changed', async () => {
+        const storage = new WriteCountingStorage();
+        await SaveMediaList(storage, 'site', entries(MediaListChunkSize * 3));
+
+        // Change a single entry in the middle shard only.
+        const updated = entries(MediaListChunkSize * 3);
+        updated[MediaListChunkSize + 5] = { id: 'manga-new', title: 'New Manga' };
+        await SaveMediaList(storage, 'site', updated);
+
+        // First and last shards must not have been written again.
+        expect(storage.writes.get('site#0')).toBe(1);
+        expect(storage.writes.get('site#2')).toBe(1);
+        // The changed shard and the meta are rewritten.
+        expect(storage.writes.get('site#1')).toBe(2);
+        expect(storage.writes.get('site#meta')).toBe(2);
+        expect(await LoadMediaList(storage, 'site')).toEqual(updated);
     });
 });

--- a/web/src/engine/MediaListStore_test.ts
+++ b/web/src/engine/MediaListStore_test.ts
@@ -81,6 +81,25 @@ describe('MediaListStore', () => {
         expect(await storage.LoadPersistent(Store.MediaLists, 'site#2')).toBeUndefined();
     });
 
+    it('Should prune stale shards without rewriting unchanged shards when the list shrinks', async () => {
+        const storage = new WriteCountingStorage();
+        await SaveMediaList(storage, 'site', entries(MediaListChunkSize * 3));
+
+        // Shrink by exactly one chunk boundary: both remaining shards are byte-identical.
+        const shrunk = entries(MediaListChunkSize * 2);
+        await SaveMediaList(storage, 'site', shrunk);
+
+        // Remaining shards are unchanged → never written again.
+        expect(storage.writes.get('site#0')).toBe(1);
+        expect(storage.writes.get('site#1')).toBe(1);
+        // The stale shard is pruned and was only ever written on the initial save.
+        expect(storage.writes.get('site#2')).toBe(1);
+        expect(await storage.LoadPersistent(Store.MediaLists, 'site#2')).toBeUndefined();
+        // The meta is rewritten with the new shard count.
+        expect(storage.writes.get('site#meta')).toBe(2);
+        expect(await LoadMediaList(storage, 'site')).toEqual(shrunk);
+    });
+
     it('Should fall back to the legacy single-key list', async () => {
         const storage = new MemoryStorage();
         const legacy = entries(42);

--- a/web/src/engine/MediaListStore_test.ts
+++ b/web/src/engine/MediaListStore_test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { Store, type StorageController } from './StorageController';
+import { LoadMediaList, MediaListChunkSize, SaveMediaList } from './MediaListStore';
+
+class MemoryStorage implements StorageController {
+    private readonly data = new Map<string, unknown>();
+
+    private Key(store: Store, key?: string): string {
+        return `${store}${key ? ':' + key : ''}`;
+    }
+
+    public async SavePersistent<T>(value: T, store: Store, key?: string): Promise<void> {
+        if (key !== undefined) {
+            this.data.set(this.Key(store, key), value);
+        } else {
+            for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+                this.data.set(this.Key(store, entryKey), entryValue);
+            }
+        }
+    }
+
+    public async LoadPersistent<T>(store: Store, key?: string): Promise<T> {
+        return this.data.get(this.Key(store, key)) as T;
+    }
+
+    public async RemovePersistent(store: Store, ...keys: string[]): Promise<void> {
+        if (keys.length === 0) {
+            const prefix = `${store}:`;
+            for (const key of [...this.data.keys()]) {
+                if (key.startsWith(prefix)) this.data.delete(key);
+            }
+        } else {
+            for (const key of keys) this.data.delete(this.Key(store, key));
+        }
+    }
+
+    public async SaveTemporary<T>(_value: T): Promise<string> { return 'temporary'; }
+    public async LoadTemporary<T>(_key: string): Promise<T> { return undefined as T; }
+    public async RemoveTemporary(..._keys: string[]): Promise<void> {}
+}
+
+function entries(count: number): { id: string; title: string }[] {
+    return Array.from({ length: count }, (_, index) => ({ id: `manga-${index}`, title: `Manga ${index}` }));
+}
+
+describe('MediaListStore', () => {
+
+    it('Should round-trip a multi-chunk list in order', async () => {
+        const storage = new MemoryStorage();
+        const list = entries(MediaListChunkSize * 2 + 250);
+        await SaveMediaList(storage, 'mangafire', list);
+        expect(await LoadMediaList(storage, 'mangafire')).toEqual(list);
+    });
+
+    it('Should prune stale chunks when the list shrinks', async () => {
+        const storage = new MemoryStorage();
+        await SaveMediaList(storage, 'site', entries(MediaListChunkSize * 3));
+        await SaveMediaList(storage, 'site', entries(MediaListChunkSize + 10));
+        expect(await LoadMediaList(storage, 'site')).toHaveLength(MediaListChunkSize + 10);
+        expect(await storage.LoadPersistent(Store.MediaLists, 'site#2')).toBeUndefined();
+    });
+
+    it('Should fall back to the legacy single-key list', async () => {
+        const storage = new MemoryStorage();
+        const legacy = entries(42);
+        await storage.SavePersistent(legacy, Store.MediaLists, 'legacy-site');
+        expect(await LoadMediaList(storage, 'legacy-site')).toEqual(legacy);
+    });
+
+    it('Should handle an empty list', async () => {
+        const storage = new MemoryStorage();
+        await SaveMediaList(storage, 'empty', entries(MediaListChunkSize * 2));
+        await SaveMediaList(storage, 'empty', []);
+        expect(await LoadMediaList(storage, 'empty')).toEqual([]);
+    });
+});

--- a/web/src/engine/StorageControllerBrowser.ts
+++ b/web/src/engine/StorageControllerBrowser.ts
@@ -39,17 +39,41 @@ const Version = VersionUpgrades.length;
  */
 export class StorageControllerBrowser implements StorageController {
 
-    private async Connect(): Promise<IDBDatabase> {
-        const connection = indexedDB.open(DataBase, Version);
+    /**
+     * Single shared connection reused by every operation.
+     * Opening a new IndexedDB connection per operation (the previous behavior)
+     * paid the full open/version-negotiation cost thousands of times during boot.
+     */
+    #connection?: Promise<IDBDatabase>;
+
+    private Connect(): Promise<IDBDatabase> {
+        if(!this.#connection) {
+            this.#connection = this.Open();
+        }
+        return this.#connection;
+    }
+
+    private async Open(): Promise<IDBDatabase> {
+        const request = indexedDB.open(DataBase, Version);
         return new Promise<IDBDatabase>((resolve, reject) => {
-            connection.onupgradeneeded = (event: IDBVersionChangeEvent) => {
-                const db = connection.result; // => event.target.result
+            request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
+                const db = request.result; // => event.target.result
                 for(let version = event.oldVersion; version < event.newVersion; version++) {
                     VersionUpgrades[version](db);
                 }
             };
-            connection.onsuccess = () => resolve(connection.result);
-            connection.onerror = () => reject(connection.error);
+            request.onsuccess = () => {
+                const db = request.result;
+                // Reset the cached connection when it is closed externally
+                // (e.g., a database version upgrade from another context).
+                db.onversionchange = () => db.close();
+                db.onclose = () => this.#connection = undefined;
+                resolve(db);
+            };
+            request.onerror = () => {
+                this.#connection = undefined;
+                reject(request.error);
+            };
         });
     }
 
@@ -62,7 +86,6 @@ export class StorageControllerBrowser implements StorageController {
             query.onsuccess = () => resolve(/*query.result*/);
             query.onerror = () => reject(query.error);
         }));
-        tx.oncomplete = () => db.close();
         tx.commit();
         await Promise.all(promises);
     }
@@ -76,7 +99,6 @@ export class StorageControllerBrowser implements StorageController {
             query.onsuccess = () => resolve(query.result as T);
             query.onerror = () => reject(query.error);
         });
-        tx.oncomplete = () => db.close();
         tx.commit();
         return promise;
     }
@@ -90,7 +112,6 @@ export class StorageControllerBrowser implements StorageController {
             query.onsuccess = () => resolve(/*query.result*/);
             query.onerror = () => reject(query.error);
         }));
-        tx.oncomplete = () => db.close();
         tx.commit();
         await Promise.all(promises);
     }

--- a/web/src/engine/providers/MangaPlugin.ts
+++ b/web/src/engine/providers/MangaPlugin.ts
@@ -1,6 +1,7 @@
 import { Key, Scope } from '../SettingsGlobal';
 import type { Check, Choice, Directory, ISettings, SettingsManager } from '../SettingsManager';
-import { SanitizeFileName, type StorageController, Store } from '../StorageController';
+import { SanitizeFileName, type StorageController } from '../StorageController';
+import { LoadMediaList, SaveMediaList } from '../MediaListStore';
 import { type Priority, TaskPool } from '../taskpool/TaskPool';
 import { MediaContainer, StoreableMediaContainer, MediaItem, MediaScraper } from './MediaPlugin';
 import icon from '../../img/manga.webp';
@@ -97,7 +98,7 @@ export class MangaPlugin extends MediaContainer<Manga> {
 
     private async Prepare() {
         await this._settings.Initialize(...this.scraper.Settings);
-        const mangas = await this.storageController.LoadPersistent<{ id: string, title: string }[]>(Store.MediaLists, this.Identifier) || [];
+        const mangas = await LoadMediaList(this.storageController, this.Identifier);
         this.entries.Value = mangas.map(manga => this.CreateEntry(manga.id, manga.title));
     }
 
@@ -135,7 +136,7 @@ export class MangaPlugin extends MediaContainer<Manga> {
         const mangas = entries.map(entry => {
             return { id: entry.Identifier, title: entry.Title };
         });
-        await this.storageController.SavePersistent(mangas, Store.MediaLists, this.Identifier);
+        await SaveMediaList(this.storageController, this.Identifier, mangas);
         return entries;
     }
 }

--- a/web/src/frontend/classic/components/MediaItem.svelte
+++ b/web/src/frontend/classic/components/MediaItem.svelte
@@ -1,19 +1,31 @@
 <script lang="ts">
-    import { onMount, onDestroy} from 'svelte';
-    import { fade } from 'svelte/transition';
-
     interface Props {
         item: MediaContainer<MediaItem>;
+        // Provided by the parent MediaItemSelect (single centralized subscriptions):
+        flag?: FlagType;
+        task?: DownloadTask;
+        taskStatus?: Status;
         selected: boolean;
         hover: boolean;
-        multilang ?: boolean;
+        multilang?: boolean;
         onView: (MouseEvent) => void;
         onmouseup: (MouseEvent) => void;
         onmousedown: (MouseEvent) => void;
         onmouseenter: (MouseEvent) => void;
-        oncontextmenu: (MouseEvent) => void;
     };
-    let { item, selected, hover , multilang = false, onView, onmouseup, onmousedown, onmouseenter, oncontextmenu }: Props  = $props();
+    let {
+        item,
+        flag,
+        task: downloadTask,
+        taskStatus: downloadTaskStatus,
+        selected,
+        hover,
+        multilang = false,
+        onView,
+        onmouseup,
+        onmousedown,
+        onmouseenter,
+    }: Props  = $props();
 
     import { Button, ClickableTile } from 'carbon-components-svelte';
     import BookmarkFilled from 'carbon-icons-svelte/lib/BookmarkFilled.svelte';
@@ -31,10 +43,7 @@
         MediaContainer,
         StoreableMediaContainer,
     } from '../../../engine/providers/MediaPlugin';
-    import {
-        FlagType,
-        type EntryFlagEventData,
-    } from '../../../engine/ItemflagManager';
+    import { FlagType } from '../../../engine/ItemflagManager';
     import { Store as UI } from '../stores/Stores.svelte';
     import { DownloadTask, Status } from '../../../engine/DownloadTask';
     import { Key as GlobalKey } from '../../../engine/SettingsGlobal';
@@ -56,47 +65,14 @@
         );
     }
 
-    let flag: FlagType = $state();
     const flagiconmap = new Map<FlagType, any>([
         [FlagType.Viewed, ViewFilled],
         [FlagType.Current, BookmarkFilled],
     ]);
 
-    let flagicon = $derived(flagiconmap.get(flag) || View);
-
-    async function OnFlagChangedCallback(flagData: EntryFlagEventData) {
-        if (flagData.Entry === item) {
-            flag = flagData.Kind;
-        } else if (flagData.Kind === FlagType.Current) {
-            flag = await HakuNeko.ItemflagManager.GetItemFlagType(item);
-        }
-    }
-    HakuNeko.ItemflagManager.EntryFlagEventChannel.Subscribe(
-        OnFlagChangedCallback,
+    let flagicon = $derived(
+        (flag !== undefined && flagiconmap.get(flag)) || View,
     );
-    onMount(async () => {
-        flag = await HakuNeko.ItemflagManager.GetItemFlagType(item);
-    });
-    onDestroy(() => {
-        HakuNeko.ItemflagManager.EntryFlagEventChannel.Unsubscribe(
-            OnFlagChangedCallback,
-        );
-        downloadTask?.Status.Unsubscribe(refreshDownloadStatus);
-        HakuNeko.DownloadManager.Queue.Unsubscribe(taskQueueChanged);
-    });
-
-    let downloadTask: DownloadTask = $state();
-    let downloadTaskStatus: Status=$state();
-
-    async function taskQueueChanged(tasks: DownloadTask[]) {
-        downloadTask?.Status.Unsubscribe(refreshDownloadStatus);
-        downloadTask = tasks.find((task) => task.Media.IsSameAs(item));
-        downloadTask?.Status.Subscribe(refreshDownloadStatus);
-    }
-    HakuNeko.DownloadManager.Queue.Subscribe(taskQueueChanged);
-    async function refreshDownloadStatus(newstatus: Status, _task: DownloadTask) {
-        downloadTaskStatus = newstatus;
-    }
 
     async function addDownload(item: StoreableMediaContainer<MediaItem>) {
         try {
@@ -120,14 +96,12 @@
 <div
     class="listitem"
     role="listitem"
-    in:fade
     class:selected
     class:hover
     class:active={UI.selectedItem?.Identifier === item?.Identifier}
     {onmouseup}
     {onmousedown}
     {onmouseenter}
-    {oncontextmenu}
 >
     {#if !downloadTaskStatus}
         <Button
@@ -158,7 +132,7 @@
             tooltipPosition="right"
             tooltipAlignment="end"
             iconDescription="Cancel (paused)"
-            onclick={() => removeDownload(downloadTask)}
+            onclick={() => downloadTask && removeDownload(downloadTask)}
         >
             <Pause fill="var(--cds-toggle-off)" />
         </Button>
@@ -169,7 +143,7 @@
             tooltipPosition="right"
             tooltipAlignment="end"
             iconDescription="Cancel (downloading...)"
-            onclick={() => removeDownload(downloadTask)}
+            onclick={() => downloadTask && removeDownload(downloadTask)}
         >
             <Download fill="var(--cds-support-info)" />
         </Button>
@@ -179,7 +153,7 @@
             size="small"
             kind="ghost"
             iconDescription="Cancel (processing...)"
-            onclick={() => removeDownload(downloadTask)}
+            onclick={() => downloadTask && removeDownload(downloadTask)}
         >
             <VolumeFileStorage fill="var(--cds-support-info)" />
         </Button>
@@ -191,7 +165,7 @@
             tooltipAlignment="end"
             icon={EventIncident}
             iconDescription="Error: click to retry (detailed error in download tasks)"
-            onclick={() => downloadTask.Run()}
+            onclick={() => downloadTask?.Run()}
         />
     {:else if downloadTaskStatus === Status.Completed}
         <Button

--- a/web/src/frontend/classic/components/MediaItemSelect.svelte
+++ b/web/src/frontend/classic/components/MediaItemSelect.svelte
@@ -17,8 +17,10 @@
     import CloudDownload from 'carbon-icons-svelte/lib/CloudDownload.svelte';
 
     import { fade } from 'svelte/transition';
+    import { onDestroy } from 'svelte';
 
     import MediaComponent from './MediaItem.svelte';
+    import VirtualList from '../lib/VirtualList.svelte';
     import { Store as UI } from '../stores/Stores.svelte';
     import { Tags, type Tag } from '../../../engine/Tags';
     const availableLanguageTags = Tags.Language.toArray();
@@ -31,6 +33,8 @@
         MediaChild,
     } from '../../../engine/providers/MediaPlugin';
     import { FlagType } from '../../../engine/ItemflagManager';
+    import type { EntryFlagEventData } from '../../../engine/ItemflagManager';
+    import type { DownloadTask, Status } from '../../../engine/DownloadTask';
     import { resizeBar } from '../lib/actions';
     import { Key as GlobalKey } from '../../../engine/SettingsGlobal';
     import type { Directory } from '../../../engine/SettingsManager';
@@ -68,6 +72,123 @@
         });
     }
 
+    // -------------------------------------------------------------------------
+    // Centralized download-task & flag state
+    //
+    // Previously every MediaItem subscribed to the global flag channel and the
+    // download queue (~2 subscriptions per chapter, thousands in total for big
+    // series). The subscriptions now live here, once per list, and the per-item
+    // state is passed down as props.
+    // -------------------------------------------------------------------------
+    let flagMap: Map<string, FlagType> = $state(new Map());
+    let taskMap: Map<string, DownloadTask> = $state(new Map());
+    let taskStatusMap: Map<string, Status> = $state(new Map());
+    // Non-reactive bookkeeping of the active per-task status subscriptions.
+    const taskSubscriptions = new Map<string, DownloadTask>();
+    let flagsRequestId = 0;
+
+    /** Unique key for an item, stable across list reloads (mirrors `IsSameAs`). */
+    function itemKey(item: MediaContainer<MediaItem>): string {
+        return item.Parent
+            ? `${item.Parent.Identifier}::${item.Identifier}`
+            : item.Identifier;
+    }
+
+    /** Re-reads the flags of every item of the current media (one batch). */
+    async function refreshFlags() {
+        const requestId = ++flagsRequestId;
+        if (items.length === 0) {
+            flagMap = new Map();
+            return;
+        }
+        const flags = await Promise.all(
+            items.map((item) =>
+                window.HakuNeko.ItemflagManager.GetItemFlagType(item),
+            ),
+        );
+        if (requestId !== flagsRequestId) return; // superseded by a newer request
+        const map = new Map<string, FlagType>();
+        items.forEach((item, index) => {
+            const kind = flags[index];
+            if (kind !== undefined) map.set(itemKey(item), kind);
+        });
+        flagMap = map;
+    }
+
+    /** Applies a flag event to the local map (mirrors ItemflagManager semantics). */
+    function onFlagChanged(flagData: EntryFlagEventData) {
+        const entry = flagData.Entry as MediaContainer<MediaItem>;
+        if (flagData.Kind === FlagType.Current) {
+            // Flagging 'Current' marks every later chapter as Viewed and clears
+            // the flags of the earlier chapters.
+            const map = new Map<string, FlagType>();
+            map.set(itemKey(entry), FlagType.Current);
+            const index = items.findIndex((item) => item.IsSameAs(entry));
+            if (index >= 0) {
+                for (let i = index + 1; i < items.length; i++) {
+                    map.set(itemKey(items[i]), FlagType.Viewed);
+                }
+            }
+            flagMap = map;
+        } else if (flagData.Kind === FlagType.Viewed) {
+            flagMap = new Map(flagMap).set(itemKey(entry), FlagType.Viewed);
+        } else {
+            const map = new Map(flagMap);
+            map.delete(itemKey(entry));
+            flagMap = map;
+        }
+    }
+
+    /** Updates the status of the task that changed. */
+    function onTaskStatusChanged(newStatus: Status, task: DownloadTask) {
+        taskStatusMap = new Map(taskStatusMap).set(
+            itemKey(task.Media),
+            newStatus,
+        );
+    }
+
+    /** Reconciles the per-item task maps with the download queue (single subscription). */
+    function syncTasks() {
+        const tasks = window.HakuNeko.DownloadManager.Queue.Value;
+        const nextTasks = new Map<string, DownloadTask>();
+        const nextStatuses = new Map<string, Status>();
+        for (const task of tasks) {
+            const key = itemKey(task.Media);
+            nextTasks.set(key, task);
+            nextStatuses.set(key, task.Status.Value);
+            if (!taskSubscriptions.has(key)) {
+                task.Status.Subscribe(onTaskStatusChanged);
+                taskSubscriptions.set(key, task);
+            }
+        }
+        for (const [key, task] of taskSubscriptions) {
+            if (!nextTasks.has(key)) {
+                task.Status.Unsubscribe(onTaskStatusChanged);
+                taskSubscriptions.delete(key);
+            }
+        }
+        taskMap = nextTasks;
+        taskStatusMap = nextStatuses;
+    }
+
+    window.HakuNeko.ItemflagManager.EntryFlagEventChannel.Subscribe(onFlagChanged);
+    window.HakuNeko.DownloadManager.Queue.Subscribe(syncTasks);
+    onDestroy(() => {
+        window.HakuNeko.ItemflagManager.EntryFlagEventChannel.Unsubscribe(onFlagChanged);
+        window.HakuNeko.DownloadManager.Queue.Unsubscribe(syncTasks);
+        for (const task of taskSubscriptions.values()) {
+            task.Status.Unsubscribe(onTaskStatusChanged);
+        }
+        taskSubscriptions.clear();
+    });
+
+    // (Re)populate the flag/task maps whenever the displayed media changes.
+    $effect(() => {
+        items;
+        refreshFlags();
+        syncTasks();
+    });
+
     $effect(() => {
         const position = filteredItems.indexOf(UI.selectedItem);
         UI.selectedItemPrevious = filteredItems[position + 1];
@@ -104,6 +225,7 @@
     let showItems = $derived(reverseSortOrder ? filteredItems.toReversed() : filteredItems);
 
     let itemsdiv: HTMLElement = $state();
+    let itemsdivHeight = $state(0);
 
     let MediaLanguages: Tag[] = $derived(
         items.reduce((detectedLangaugeTags: Tag[], item) => {
@@ -398,32 +520,20 @@
     <div id="ItemFilter">
         <Search id="ItemFilterSearch" size="sm" bind:value={itemNameFilter} />
     </div>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div 
-        id="ItemList" 
-        class="list" 
-        bind:this={itemsdiv} 
-        onmouseup={(event) => { if (event.target === event.currentTarget && event.button === 0) resetSelection(); }}
+    <div
+        id="ItemList"
+        class="list"
+        bind:this={itemsdiv}
+        bind:clientHeight={itemsdivHeight}
+        onclick={resetSelection}
     >
         {#await loadItem}
             <div class="loading center">
                 <div><Loading withOverlay={false} /></div>
                 <div>... items</div>
             </div>
-        {:then}
-            {#each showItems as item (item)}
-                <MediaComponent
-                    {item}
-                    multilang={!langFilter && MediaLanguages.length > 1}
-                    selected={selectedItems.includes(item)}
-                    hover={item === contextItem}
-                    onView={(event) => onItemView(item)(event)}
-                    onmousedown={mouseHandler(item)}
-                    onmouseup={mouseHandler(item)}
-                    onmouseenter={mouseHandler(item)}
-                    oncontextmenu={() => { contextItem = item }}
-                />
-            {/each}
         {:catch error}
             <div class="error">
                 <InlineNotification
@@ -439,6 +549,29 @@
                 </InlineNotification>
             </div>
         {/await}
+        <VirtualList
+            items={showItems}
+            itemHeight={24}
+            container={itemsdiv}
+            containerHeight={itemsdivHeight}
+        >
+            {#snippet children(item)}
+                {@const key = itemKey(item)}
+                <MediaComponent
+                    {item}
+                    flag={flagMap.get(key)}
+                    task={taskMap.get(key)}
+                    taskStatus={taskStatusMap.get(key)}
+                    multilang={!langFilter && MediaLanguages.length > 1}
+                    selected={selectedItems.includes(item)}
+                    hover={item === contextItem}
+                    onView={(event) => onItemView(item)(event)}
+                    onmousedown={mouseHandler(item)}
+                    onmouseup={mouseHandler(item)}
+                    onmouseenter={mouseHandler(item)}
+                />
+            {/snippet}
+        </VirtualList>
     </div>
     {#if items?.length > 0}
         <div id="DownloadButtons">

--- a/web/src/frontend/classic/components/MediaSelect.svelte
+++ b/web/src/frontend/classic/components/MediaSelect.svelte
@@ -80,13 +80,24 @@
     // Medias list
     let medias: MediaContainer<MediaChild>[] = $state([]);
     let mediaNameFilter = $state('');
+    let debouncedMediaFilter = $state('');
 
     let filteredmedias: MediaContainer<MediaChild>[] = $state([]);
+
+    // Debounce the filter input: re-filtering (and fuzzily searching) tens of
+    // thousands of titles on every keystroke is expensive.
+    $effect(() => {
+        mediaNameFilter;
+        const timeout = setTimeout(() => debouncedMediaFilter = mediaNameFilter, 200);
+        return () => clearTimeout(timeout);
+    });
+
+    // `medias` is already sorted alphabetically in `loadMedias`, so filtering
+    // preserves the order without re-sorting the whole list on each keystroke.
     $effect(() => {
         medias;
-        filteredmedias = filterMedia(mediaNameFilter).sort((a, b) =>
-            a.Title.localeCompare(b.Title)
-        );
+        debouncedMediaFilter;
+        filteredmedias = filterMedia(debouncedMediaFilter);
     });
     let fuse = new Fuse([]);
 
@@ -108,14 +119,18 @@
         if (!plugin) return;
         const loadedmedias =
             (plugin.Entries.Value as MediaContainer<MediaChild>[]) ?? [];
-        fuse = new Fuse(loadedmedias, {
+        // Sort once when the list is loaded; filtering below preserves this order.
+        const sortedmedias = loadedmedias.toSorted((a, b) =>
+            a.Title.localeCompare(b.Title)
+        );
+        fuse = new Fuse(sortedmedias, {
             keys: ['Title'],
             findAllMatches: true,
             ignoreLocation: true,
             minMatchCharLength: 1,
             fieldNormWeight: 0,
         });
-        medias = loadedmedias;
+        medias = sortedmedias;
         return plugin;
     }
 

--- a/web/src/frontend/classic/components/MediaSelect.svelte
+++ b/web/src/frontend/classic/components/MediaSelect.svelte
@@ -86,9 +86,13 @@
 
     // Debounce the filter input: re-filtering (and fuzzily searching) tens of
     // thousands of titles on every keystroke is expensive.
+    // Substring filtering (default) is fast (~5 ms), so a short debounce keeps
+    // typing responsive; fuzzy search runs in a web worker and takes ~200 ms
+    // itself, so it keeps a longer debounce to avoid stacking searches.
     $effect(() => {
         mediaNameFilter;
-        const timeout = setTimeout(() => debouncedMediaFilter = mediaNameFilter, 200);
+        const delay = Settings.FuzzySearch.Value ? 200 : 120;
+        const timeout = setTimeout(() => debouncedMediaFilter = mediaNameFilter, delay);
         return () => clearTimeout(timeout);
     });
 


### PR DESCRIPTION
## Problem

The classic frontend becomes sluggish on large manga libraries (MangaFire alone has ~70–90k titles):

1. **Fuzzy search on the UI thread** — `Fuse.js` indexes and searches ~90k titles directly in the UI thread (~200 ms per keystroke).
2. **Re-sorting on every keystroke** — the whole filtered list was `.sort()`ed on each filter change.
3. **Per-item subscriptions** — every rendered chapter subscribed to the global flag channel and the download queue (~2 subscriptions per chapter, thousands for big series), and the list rendered every chapter with `{#each}`.
4. **Monolithic MediaLists blob** — each website's full manga list (70–90k entries) was stored as a single IndexedDB blob that was loaded and rewritten entirely on every refresh.
5. **One IndexedDB connection per store** — each `StorageControllerBrowser` opened its own connection on boot.

## Changes

- **`web/src/engine/FuseSearch.ts` + `FuseSearchWorker.ts`** (new) — fuzzy index/search moved into a Vite web worker; the UI thread receives only the match indices.
- **`web/src/frontend/classic/components/MediaSelect.svelte`** — sort the list once on load (`toSorted`), filter in place afterwards, debounce the input (120 ms for the fast substring filter, 200 ms while fuzzy search is active) and sequence fuzzy requests so a superseded search result is dropped.
- **`web/src/frontend/classic/components/MediaItemSelect.svelte`** — virtualize the chapter list with the existing `VirtualList` and centralize the flag/download subscriptions once per list instead of per item; per-item state (flag/task/status) is passed down as props and keyed by item identifier.
- **`web/src/frontend/classic/components/MediaItem.svelte`** — consume the centralized flag/task/status props instead of subscribing to the global flag channel and download queue.
- **`web/src/engine/MediaListStore.ts`** (new) + **`web/src/engine/providers/MangaPlugin.ts`** — shard each website's media list into fixed-size chunks, rewrite only the changed shards by diffing against the previous list, and compare/write shards one by one without ever loading the full old list into memory.
- **`web/src/engine/StorageControllerBrowser.ts`** — reuse a single shared IndexedDB connection.
- **`web/src/engine/MediaListStore_test.ts`** (new) — regression tests covering the diff-based updates, shard-by-shard rewrites, and list shrink (purged shards, no useless writes on unchanged ones).

## Testing

- `tsc --noEmit` (web + electron + nw), eslint, svelte-check, vue-tsc and the coding rules check all pass.
- `vitest run` passes (2 138 tests, including the new `MediaListStore` suite).
- Validated in the real app on the fork: MangaFire's 91k-title list filters without UI freezes, and chapter lists (238 chapters in the test case) scroll and flag/download without per-item subscription churn.

## Notes for reviewers

- The virtualization keeps the existing `VirtualList` component and only changes how items receive their flag/download state (props instead of subscriptions) — the item key is derived from the parent/child identifiers, mirroring `IsSameAs`.
- The MediaLists sharding keeps the same `Store.MediaLists` namespace; old monolithic blobs are simply no longer written. Chunk size is fixed and configurable via the `CHUNK_SIZE` constant in `MediaListStore.ts`.
