### PR TITLE
Allow git fetching for npm =>12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 engine-strict = true
-allow-git=root
+allow-git = root

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict = true
+allow-git=root


### PR DESCRIPTION
NPM version since 12x are restricted to fetch from Git repos.
<img width="1076" height="182" alt="image" src="https://github.com/user-attachments/assets/d5c74e46-f644-4abf-9e75-439695810f2b" />

This PR lift the restriction for packages explicitly listed in package.json only. 

Since we control the "websocket" repository there shouldnt be any problem.

