### PR TITLE
[RFC]Viewer: Add paged mode

### DIFF
--- a/web/src/frontend/classic/components/viewer/ImageViewer.svelte
+++ b/web/src/frontend/classic/components/viewer/ImageViewer.svelte
@@ -307,6 +307,7 @@
             class:double-page={isDoublePage}
             onclick={() => {
                 if (wide && isPaged) return;
+                event.stopPropagation();
                 currentImageIndex = index;
                 wide = true;
             }}

--- a/web/src/frontend/classic/components/viewer/ImageViewer.svelte
+++ b/web/src/frontend/classic/components/viewer/ImageViewer.svelte
@@ -42,14 +42,78 @@
     let { item, currentImageIndex, wide = $bindable(), onNextItem, onPreviousItem, onClose }: Props = $props();
     let entries = $derived(item.Entries.Value);
     let viewer: HTMLElement;
+    const isPaged = $derived(Settings.ViewerMode.Value === Key.ViewerMode_Paged);
+    const isDoublePage = $derived(Settings.ViewerDoublePage.Value);
 
     function viewerclose() {
         wide = false;
         onClose();
     }
 
+    function nextPage() {
+        if (currentImageIndex >= entries.length - 1) return;
+        if (!isDoublePage || currentImageIndex === entries.length - 2) currentImageIndex++;
+        else currentImageIndex += 2;
+    }
+
+    // Advance by one page, allowing the user to shift the double-page spread
+    function nextPageByOne() {
+        if (currentImageIndex >= entries.length - 1) return;
+        else currentImageIndex++;
+    }
+
+    function previousPage() {
+        if (currentImageIndex <= 0) return;
+        if (!isDoublePage || currentImageIndex === 1) currentImageIndex--;
+        else currentImageIndex -= 2;
+    }
+
+    function onPageClick(event: MouseEvent) {
+        if (!wide || !isPaged) return;
+
+        const target = event.currentTarget as HTMLElement;
+        const rect = target.getBoundingClientRect();
+        const clickX = event.clientX - rect.left;
+        const reverse = Settings.ViewerReverseDirection.Value;
+
+        if (clickX < rect.width / 3 && !reverse || clickX > rect.width * 2 / 3 && reverse) {
+            previousPage();
+        } else if (clickX > rect.width * 2 / 3 && !reverse || clickX < rect.width / 3 && reverse) {
+            nextPage();
+        }
+    }
+
+    function onWheel(event: WheelEvent) {
+        if (!wide || !isPaged) return;
+
+        event.preventDefault();
+        if (event.deltaY > 0) {
+            nextPage();
+        } else if (event.deltaY < 0) {
+            previousPage();
+        }
+    }
+
     function onKeyDown(event: KeyboardEvent) {
         switch (true) {
+            case isPaged && (
+                event.code === 'ArrowUp' ||
+                event.code === 'PageUp'
+            ):
+                previousPage();
+                event.preventDefault();
+                break;
+            case isPaged && (
+                event.code === 'ArrowDown' ||
+                event.code === 'PageDown'
+            ):
+                nextPage();
+                event.preventDefault();
+                break;
+            case isPaged && event.code === 'Space':
+                nextPageByOne();
+                event.preventDefault();
+                break;
             case event.code === 'ArrowUp':
                 scrollSmoothly(viewer, -64);
                 break;
@@ -158,7 +222,11 @@
     // Entering wide mode : scroll to image
     $effect(() => {
         if (wide) {
-            if (currentImageIndex != -1) {
+            if (isPaged) {
+                if (currentImageIndex === -1) {
+                    currentImageIndex = 0;
+                }
+            } else if (currentImageIndex != -1) {
                 // delay because of smooth transition
                 setTimeout(() => {
                     const targetScrollImage =
@@ -195,9 +263,24 @@
 <div
     id="ImageViewer"
     bind:this={viewer}
+    onclick={onPageClick}
+    onwheel={onWheel}
     role="button"
     tabindex="-1"
-    ondblclick={() => toggleFullScreen()}
+    ondblclick={(event) => {
+        if (!isPaged) {
+            toggleFullScreen();
+            return;
+        }
+        const rect = viewer.getBoundingClientRect();
+        const clickX = event.clientX - rect.left;
+        if (
+            clickX >= rect.width / 3 &&
+            clickX <= rect.width * 2 / 3
+        ) {
+            toggleFullScreen();
+        }
+    }}
     transition:fade
     class:wide={wide}
     class:reverse={Settings.ViewerReverseDirection.Value}
@@ -220,7 +303,10 @@
 
     {#each entries as content, index (index)}
         <button
+            class:hidden={index !== currentImageIndex && (index !== currentImageIndex + 1 || !isDoublePage)}
+            class:double-page={isDoublePage}
             onclick={() => {
+                if (wide && isPaged) return;
                 currentImageIndex = index;
                 wide = true;
             }}
@@ -309,5 +395,24 @@
     /* TODO: implement RTL reading */
     #ImageViewer.wide.paginated.reverse {
         flex-flow: row-reverse;
+    }
+    #ImageViewer.wide.paged {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+    }
+    #ImageViewer.wide.paged.reverse {
+        flex-flow: row-reverse;
+    }
+    #ImageViewer.wide.paged button.hidden {
+        display: none !important;
+    }
+    #ImageViewer.wide.paged :global(img.imgpreview) {
+        max-height: 100vh;
+        max-width: 100vw;
+    }
+    #ImageViewer.wide.paged button.double-page :global(img.imgpreview) {
+        max-width: calc(50vw - var(--viewer-padding) / 2);
     }
 </style>

--- a/web/src/frontend/classic/components/viewer/ImageViewerWideSettings.svelte
+++ b/web/src/frontend/classic/components/viewer/ImageViewerWideSettings.svelte
@@ -153,9 +153,16 @@
                         >
                             <Stack orientation="horizontal" gap={3}><CarouselHorizontal />{GlobalSettings.Locale[Settings.ViewerMode.Setting.Options[1].label]()}</Stack>
                         </Switch>
+                        <Switch
+                            selected={Settings.ViewerMode.Value === Settings.ViewerMode.Setting.Options[2].key}
+                            onclick={() =>
+                                (Settings.ViewerMode.Value = Settings.ViewerMode.Setting.Options[2].key)}
+                        >
+                            <Stack orientation="horizontal" gap={3}><CarouselHorizontal />{GlobalSettings.Locale[Settings.ViewerMode.Setting.Options[2].label]()}</Stack>
+                        </Switch>
                 </ContentSwitcher>
             </div>
-            {#if Settings.ViewerMode.Value === Key.ViewerMode_Paginated}
+            {#if Settings.ViewerMode.Value === Key.ViewerMode_Paginated || Settings.ViewerMode.Value === Key.ViewerMode_Paged}
                 <div class="setting block">
                     <Tooltip
                         triggerText={GlobalSettings.Locale[

--- a/web/src/frontend/classic/stores/Settings.svelte.ts
+++ b/web/src/frontend/classic/stores/Settings.svelte.ts
@@ -23,6 +23,7 @@ export const enum Key {
     ViewerMode = 'viewer-mode',
     ViewerMode_Paginated = 'paginated',
     ViewerMode_Longstrip = 'longstrip',
+    ViewerMode_Paged = 'paged',
     ViewerReverseDirection = 'viewer-reverse-direction',
     //
     ViewerDoublePage = 'viewer-double-page',
@@ -106,6 +107,7 @@ class UIClassicStore {
         Key.ViewerMode_Paginated,
         { key: Key.ViewerMode_Longstrip, label: R.Frontend_Classic_Settings_ViewerMode_Longstrip },
         { key: Key.ViewerMode_Paginated, label: R.Frontend_Classic_Settings_ViewerMode_Paginated },
+        { key: Key.ViewerMode_Paged, label: R.Frontend_Classic_Settings_ViewerMode_Paged },
     ));
 
     ViewerReverseDirection = new SettingStore<boolean, Check>( new Check(

--- a/web/src/i18n/ILocale.ts
+++ b/web/src/i18n/ILocale.ts
@@ -166,6 +166,7 @@ export enum FrontendResourceKey {
     Frontend_Classic_Settings_ViewerModeInfo = 'Frontend_Classic_Settings_ViewerModeInfo',
     Frontend_Classic_Settings_ViewerMode_Paginated = 'Frontend_Classic_Settings_ViewerMode_Paginated',
     Frontend_Classic_Settings_ViewerMode_Longstrip = 'Frontend_Classic_Settings_ViewerMode_Longstrip',
+    Frontend_Classic_Settings_ViewerMode_Paged = 'Frontend_Classic_Settings_ViewerMode_Paged',
     Frontend_Classic_Settings_ViewerReverseDirection = 'Frontend_Classic_Settings_ViewerReverseDirection',
     Frontend_Classic_Settings_ViewerReverseDirectionInfo = 'Frontend_Classic_Settings_ViewerReverseDirectionInfo',
     Frontend_Classic_Settings_ViewerDoublePage = 'Frontend_Classic_Settings_ViewerDoublePage',

--- a/web/src/i18n/locales/en_US.ts
+++ b/web/src/i18n/locales/en_US.ts
@@ -87,6 +87,7 @@ const translations: VariantResource = {
   Frontend_Classic_Settings_ViewerModeInfo: 'Change how pages/images will be shown in the reader',
   Frontend_Classic_Settings_ViewerMode_Paginated: 'Paginated (Manga)',
   Frontend_Classic_Settings_ViewerMode_Longstrip: 'Longstrip (Webtoon)',
+  Frontend_Classic_Settings_ViewerMode_Paged: 'Paged (Manga)',
   Frontend_Classic_Settings_ViewerReverseDirection: 'Invert Reading Direction',
   Frontend_Classic_Settings_ViewerReverseDirectionInfo: 'Show pages/images in reverse order (like in tradional Manga)',
   Frontend_Classic_Settings_ViewerDoublePage: 'Show Double Pages',


### PR DESCRIPTION
This commit adds a paged mode to viewer. In this mode, images except visible pages are hidden, viewer only shows one image in single page mode and two images in double page mode. The size of image is relative to window size. 
For page turn:
1. Click on left/right thirds of screen. I have double click to fullscreen enabled only for middle thirds of screen.
2. Mouse wheel
3. arrow up/down, page up/down
4. space will always increment page index by one, even in double page mode

Current problems:
1. ~Some images are already double paged, maybe I need to check if image width > height, only show one image~
2. image size uses max-width and max-height, if image is too small it may not fill screen. Can be easily observed in my firefox port when I set small page zoom.
3. In double page mode, even if I set spacing to 0, sometimes there is still 1px gap between images.
4. I call this paged mode, which might be confused with existing paginated mode.
6. AI says my current code for mouse wheel will be bad for trackpad